### PR TITLE
pMatrix is now a vector of vector, and not a vector of matrix.

### DIFF
--- a/stan/math/torsten/GeneralCptModel_bdf.hpp
+++ b/stan/math/torsten/GeneralCptModel_bdf.hpp
@@ -48,7 +48,7 @@ Eigen::Matrix <typename promote_args<T0, T1, T2, T3, T4>::type, Eigen::Dynamic,
   Eigen::Dynamic> 
 generalCptModel_bdf(const F& f,
                     const int nCmt,
-			        const std::vector< Eigen::Matrix<T0, Eigen::Dynamic, 1> >& pMatrix, 
+			        const std::vector<vector<T0> >& pMatrix, 
 			        const std::vector<T1>& time,
 			        const std::vector<T2>& amt,
 			        const std::vector<T3>& rate,
@@ -66,7 +66,7 @@ generalCptModel_bdf(const F& f,
   using boost::math::tools::promote_args;
 
   int nParameters, F1Index, tlag1Index;
-  nParameters = pMatrix[0].rows();
+  nParameters = pMatrix[0].size();
   F1Index = nParameters - 2*nCmt;
   tlag1Index = nParameters - nCmt;
   PKModel model(nParameters, F1Index, tlag1Index, nCmt);

--- a/stan/math/torsten/GeneralCptModel_rk45.hpp
+++ b/stan/math/torsten/GeneralCptModel_rk45.hpp
@@ -48,7 +48,7 @@ Eigen::Matrix <typename promote_args<T0, T1, T2, T3, T4>::type, Eigen::Dynamic,
   Eigen::Dynamic> 
 generalCptModel_rk45(const F& f,
                      const int nCmt,
-			         const std::vector< Eigen::Matrix<T0, Eigen::Dynamic, 1> >& pMatrix, 
+			         const std::vector<vector<T0> >& pMatrix, 
 			         const std::vector<T1>& time,
 			         const std::vector<T2>& amt,
 			         const std::vector<T3>& rate,
@@ -67,7 +67,7 @@ generalCptModel_rk45(const F& f,
 
   //Define class of model
   int nParameters, F1Index, tlag1Index;
-  nParameters = pMatrix[0].rows();
+  nParameters = pMatrix[0].size();
   F1Index = nParameters - 2*nCmt;
   tlag1Index = nParameters - nCmt;
   PKModel model(nParameters, F1Index, tlag1Index, nCmt);

--- a/stan/math/torsten/PKModel/Event.hpp
+++ b/stan/math/torsten/PKModel/Event.hpp
@@ -135,7 +135,7 @@ public:
 	friend
 	Matrix<typename promote_args<T_0, T_1, T_2, T_3,
 	 typename promote_args<T_4, T_5>::type >::type, Dynamic, Dynamic>
-	Pred(const vector< Matrix<T_0, Dynamic, 1> >& pMatrix,
+	Pred(const vector<vector<T_0> >& pMatrix,
      	 const vector<T_1>& time,
      	 const vector<T_2>& amt, 
      	 const vector<T_3>& rate,
@@ -364,7 +364,7 @@ public:
 	friend
 	Matrix<typename promote_args<T_0, T_1, T_2, T_3,
 	 typename promote_args<T_4, T_5>::type >::type, Dynamic, Dynamic>
-	Pred(const vector< Matrix<T_0, Dynamic, 1> >& pMatrix,
+	Pred(const vector<vector<T_0> >& pMatrix,
      	 const vector<T_1>& time,
      	 const vector<T_2>& amt, 
      	 const vector<T_3>& rate,

--- a/stan/math/torsten/PKModel/ModelParameters.hpp
+++ b/stan/math/torsten/PKModel/ModelParameters.hpp
@@ -125,7 +125,7 @@ public:
 	friend
 	Matrix<typename promote_args<T_0, T_1, T_2, T_3,
 	 typename promote_args<T_4, T_5>::type >::type, Dynamic, Dynamic>
-	Pred(const vector< Matrix<T_0, Dynamic, 1> >& pMatrix,
+	Pred(const vector<vector<T_0> >& pMatrix,
      	 const vector<T_1>& time,
      	 const vector<T_2>& amt, 
      	 const vector<T_3>& rate,
@@ -154,18 +154,16 @@ private:
 public:
 	template<typename T0, typename T1, typename T3>
 	ModelParameterHistory(vector<T0> p_time, 
-						  vector< Matrix<T1, Dynamic, 1> > p_RealParameters,
+						  vector<vector<T1> > p_RealParameters,
 						  vector< Matrix<T3, Dynamic, Dynamic> > p_K) {
 		int nParameters = std::max(p_RealParameters.size(), p_K.size()); 
-		vector<T_parameters> col;
 		MPV.resize(nParameters);
 		int j, k;
 		for(int i = 0; i < nParameters; i++) {
 		    (p_RealParameters.size() == 1) ? j = 0 : j = i;
-			col = ExtractVector(p_RealParameters[j], 0, "col");
 			(p_K.size() == 1) ? k = 0 : k = i;
 			MPV[i] = ModelParameters<T_time, T_parameters, T_system>
-		      (p_time[i], col, p_K[k]);
+		      (p_time[i], p_RealParameters[j], p_K[k]);
 		}
 	}
 
@@ -174,7 +172,7 @@ public:
 		  newPara(MPV[i].time, MPV[i].RealParameters, MPV[i].K);
 		return newPara;
 	}
-	
+
 	T_parameters GetValue(int iEvent, int iParameter) {
 		// MPV.size gives us the number of events
 		// MPV[0].RealParameters.size gives us the number of parameters for the first event. 
@@ -328,7 +326,7 @@ public:
 	friend
 	Matrix<typename promote_args<T_0, T_1, T_2, T_3,
 	 typename promote_args<T_4, T_5>::type >::type, Dynamic, Dynamic>
-	Pred(const vector< Matrix<T_0, Dynamic, 1> >& pMatrix,
+	Pred(const vector<vector<T_0> >& pMatrix,
      	 const vector<T_1>& time,
      	 const vector<T_2>& amt, 
      	 const vector<T_3>& rate,

--- a/stan/math/torsten/PKModel/Pred.hpp
+++ b/stan/math/torsten/PKModel/Pred.hpp
@@ -45,9 +45,11 @@
  * @parem[in] model basic structural information on compartment
  * model
  * @param[in] f functor for base ordinary differential equation
- * that defines compartment model. Used for ODE integrators.
+ * that defines compartment model. Used for ODE integrators
+ * (optional).
  * @param[in] SystemODE matrix describing linear ODE system that
- * defines compartment model. Used for matrix exponential solutions.
+ * defines compartment model. Used for matrix exponential solutions
+ * (optional).
  * @return a matrix with predicted amount in each compartment
  * at each event.
  */
@@ -55,7 +57,7 @@ template <typename T_parameters, typename T_time, typename T_amt, typename T_rat
 		  typename T_ii, typename F, typename T_system>
 Eigen::Matrix<typename promote_args<T_parameters, T_time, T_amt, T_rate,
 	 typename promote_args<T_ii, T_system>::type >::type, Eigen::Dynamic, Eigen::Dynamic>
-Pred(const std::vector< Eigen::Matrix<T_parameters, Eigen::Dynamic, 1> >& pMatrix,
+Pred(const std::vector<vector<T_parameters> >& pMatrix,
      const std::vector<T_time>& time,
      const std::vector<T_amt>& amt,
      const std::vector<T_rate>& rate,
@@ -127,9 +129,6 @@ Pred(const std::vector< Eigen::Matrix<T_parameters, Eigen::Dynamic, 1> >& pMatri
 	init = zeros;
 	tprev = events.get_time(0);
 	ikeep = 0;
-	
-	// line();
-	// for(int i = 0; i < events.Events.size(); i++) events.Print(i);
 
 	// Construct the output matrix pred
 	// The matrix needs to be a dynamically-sized matrix to be returned

--- a/stan/math/torsten/PKModel/Rate.hpp
+++ b/stan/math/torsten/PKModel/Rate.hpp
@@ -51,7 +51,7 @@ public:
 	friend
 	Matrix<typename promote_args<T_0, T_1, T_2, T_3,
 	 typename promote_args<T_4, T_5>::type >::type, Dynamic, Dynamic>
-	Pred(const vector< Matrix<T_0, Dynamic, 1> >& pMatrix,
+	Pred(const vector<vector<T_0> >& pMatrix,
      	 const vector<T_1>& time,
      	 const vector<T_2>& amt, 
      	 const vector<T_3>& rate,
@@ -221,7 +221,7 @@ public:
 	friend
 	Matrix<typename promote_args<T_0, T_1, T_2, T_3,
 	 typename promote_args<T_4, T_5>::type >::type, Dynamic, Dynamic>
-	Pred(const vector< Matrix<T_0, Dynamic, 1> >& pMatrix,
+	Pred(const vector<vector<T_0> >& pMatrix,
      	 const vector<T_1>& time,
      	 const vector<T_2>& amt, 
      	 const vector<T_3>& rate,

--- a/stan/math/torsten/PKModel/pmetricsCheck.hpp
+++ b/stan/math/torsten/PKModel/pmetricsCheck.hpp
@@ -39,7 +39,7 @@
  */
 
 template <typename T0, typename T1, typename T2, typename T3, typename T4> 
-void pmetricsCheck(const std::vector< Eigen::Matrix<T0, Eigen::Dynamic, 1> >& pMatrix, 
+void pmetricsCheck(const std::vector<vector<T0> >& pMatrix, 
                    const std::vector<T1>& time,
                    const std::vector<T2>& amt,
                    const std::vector<T3>& rate,
@@ -101,7 +101,7 @@ void pmetricsCheck(const std::vector< Eigen::Matrix<T0, Eigen::Dynamic, 1> >& pM
 
   	// TEST ARGUMENTS FOR PARAMETERS
   	if (!((pMatrix.size() == time.size())||(pMatrix.size() == 1)))
-  	  invalid_argument(function, "length of the parameter (2d) vector,",
+  	  invalid_argument(function, "length of the parameter (2d) array,",
   	  pMatrix.size(), "", length_error2);
   	if(!(pMatrix[0].size() > 0)) invalid_argument(function,
       "the number of parameters per event is", pMatrix[0].size(),

--- a/stan/math/torsten/PKModelOneCpt.hpp
+++ b/stan/math/torsten/PKModelOneCpt.hpp
@@ -36,7 +36,7 @@
 template <typename T0, typename T1, typename T2, typename T3, typename T4> 
 Eigen::Matrix <typename promote_args<T0, T1, T2, T3, T4>::type, Eigen::Dynamic,
   Eigen::Dynamic> 
-PKModelOneCpt(const std::vector< Eigen::Matrix<T0, Eigen::Dynamic, 1> >& pMatrix, 
+PKModelOneCpt(const std::vector<vector<T0> >& pMatrix, 
 			  const std::vector<T1>& time,
 			  const std::vector<T2>& amt,
 			  const std::vector<T3>& rate,
@@ -58,9 +58,9 @@ PKModelOneCpt(const std::vector< Eigen::Matrix<T0, Eigen::Dynamic, 1> >& pMatrix
   static const char* function("PKModelOneCpt");
   pmetricsCheck(pMatrix, time, amt, rate, ii, evid, cmt, addl, ss, function, model);
   for(int i=0; i<pMatrix.size(); i++) {
-	check_positive_finite(function, "PK parameter CL", pMatrix[i](0,0));
-	check_positive_finite(function, "PK parameter V2", pMatrix[i](1,0));
-    check_positive_finite(function, "PK parameter ka", pMatrix[i](2,0));
+	check_positive_finite(function, "PK parameter CL", pMatrix[i][0]);
+	check_positive_finite(function, "PK parameter V2", pMatrix[i][1]);
+    check_positive_finite(function, "PK parameter ka", pMatrix[i][2]);
   }
   std::string message4 = ", but must equal the number of parameters in the model: " 
     + boost::lexical_cast<string>(model.GetNParameter()) + "!"; 

--- a/stan/math/torsten/linCptModel.hpp
+++ b/stan/math/torsten/linCptModel.hpp
@@ -48,7 +48,7 @@ Eigen::Matrix <typename promote_args<T0, T1, T2, T3, T4>::type, Eigen::Dynamic,
   Eigen::Dynamic>
 linCptModel(const std::vector< Eigen::Matrix<T0, Eigen::Dynamic,
               Eigen::Dynamic> >& system,
-			const std::vector< Eigen::Matrix<T1, Eigen::Dynamic, 1> >& pMatrix,
+			const std::vector<vector<T1> >& pMatrix,
 			const std::vector<T2>& time,
 			const std::vector<T3>& amt,
 			const std::vector<T4>& rate,
@@ -71,7 +71,7 @@ linCptModel(const std::vector< Eigen::Matrix<T0, Eigen::Dynamic,
   int nCmt = system[0].cols();
 
   int nParameters, F1Index, tlag1Index;
-  nParameters = pMatrix[0].rows();
+  nParameters = pMatrix[0].size();
   F1Index = nParameters - 2*nCmt;
   tlag1Index = nParameters - nCmt;
   PKModel model(nParameters, F1Index, tlag1Index, nCmt);

--- a/test/unit/math/torsten/prim/PKModelOneCpt_test.cpp
+++ b/test/unit/math/torsten/prim/PKModelOneCpt_test.cpp
@@ -1,4 +1,3 @@
-// #include <stan/math/prim/mat.hpp>
 #include <stan/math/torsten/torsten.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/prim/mat/fun/expect_matrix_eq.hpp>
@@ -9,15 +8,15 @@ using Eigen::Dynamic;
 
 TEST(Torsten, PKModelOneCpt_MultipleDoses) {
 
-	vector<Matrix<double, Dynamic, 1> > pMatrix(1);
+	vector<vector<double> > pMatrix(1);
 	pMatrix[0].resize(7);
-	pMatrix[0](0) = 10; // CL
-	pMatrix[0](1) = 80; // Vc
-	pMatrix[0](2) = 1.2; // ka
-	pMatrix[0](3) = 1; // F1
-	pMatrix[0](4) = 1; // F2
-	pMatrix[0](5) = 0; // tlag1
-	pMatrix[0](6) = 0; // tlag2
+	pMatrix[0][0] = 10; // CL
+	pMatrix[0][1] = 80; // Vc
+	pMatrix[0][2] = 1.2; // ka
+	pMatrix[0][3] = 1; // F1
+	pMatrix[0][4] = 1; // F2
+	pMatrix[0][5] = 0; // tlag1
+	pMatrix[0][6] = 0; // tlag2
 	
 	vector<double> time(10);
 	time[0] = 0.0;
@@ -61,18 +60,17 @@ TEST(Torsten, PKModelOneCpt_MultipleDoses) {
 	expect_matrix_eq(amounts, x);
 }
 
-
 TEST(Torsten, PKModelOneCpt_SS) {
 
-	vector<Matrix<double, Dynamic, 1> > pMatrix(1);
+	vector<vector<double> > pMatrix(1);
 	pMatrix[0].resize(7);
-	pMatrix[0](0) = 10; // CL
-	pMatrix[0](1) = 80; // Vc
-	pMatrix[0](2) = 1.2; // ka
-	pMatrix[0](3) = 1; // F1
-	pMatrix[0](4) = 1; // F2
-	pMatrix[0](5) = 0; // tlag1
-	pMatrix[0](6) = 0; // tlag2
+	pMatrix[0][0] = 10; // CL
+	pMatrix[0][1] = 80; // Vc
+	pMatrix[0][2] = 1.2; // ka
+	pMatrix[0][3] = 1; // F1
+	pMatrix[0][4] = 1; // F2
+	pMatrix[0][5] = 0; // tlag1
+	pMatrix[0][6] = 0; // tlag2
 	
 	vector<double> time(10);
 	time[0] = 0.0;
@@ -122,15 +120,15 @@ TEST(Torsten, PKModelOneCpt_SS) {
 
 TEST(Torsten, PKModelOneCpt_SS_rate) {
 	
-	vector<Matrix<double, Dynamic, 1> > pMatrix(1);
+	vector<vector<double> > pMatrix(1);
 	pMatrix[0].resize(7);
-	pMatrix[0](0) = 10; // CL
-	pMatrix[0](1) = 80; // Vc
-	pMatrix[0](2) = 1.2; // ka
-	pMatrix[0](3) = 1; // F1
-	pMatrix[0](4) = 1; // F2
-	pMatrix[0](5) = 0; // tlag1
-	pMatrix[0](6) = 0; // tlag2
+	pMatrix[0][0] = 10; // CL
+	pMatrix[0][1] = 80; // Vc
+	pMatrix[0][2] = 1.2; // ka
+	pMatrix[0][3] = 1; // F1
+	pMatrix[0][4] = 1; // F2
+	pMatrix[0][5] = 0; // tlag1
+	pMatrix[0][6] = 0; // tlag2
 
 	vector<double> time(10);
 	time[0] = 0.0;
@@ -183,18 +181,18 @@ TEST(Torsten, PKModelOneCpt_MultipleDoses_timePara) {
 
     int nEvent = 11;
     
-	vector<Matrix<double, Dynamic, 1> > pMatrix(nEvent);
+	vector<vector<double> > pMatrix(nEvent);
 	
 	for (int i = 0; i < nEvent; i++) {
 	  pMatrix[i].resize(7);
-	  if (i < 6) pMatrix[i](0) = 10; // CL
-	  else pMatrix[i](0) = 50; // CL is piece-wise constant
-	  pMatrix[i](1) = 80; // Vc
-	  pMatrix[i](2) = 1.2; // ka
-	  pMatrix[i](3) = 1; // F1
-	  pMatrix[i](4) = 1; // F2
-	  pMatrix[i](5) = 0; // tlag1
-	  pMatrix[i](6) = 0; // tlag2
+	  if (i < 6) pMatrix[i][0] = 10; // CL
+	  else pMatrix[i][0] = 50; // CL is piece-wise constant
+	  pMatrix[i][1] = 80; // Vc
+	  pMatrix[i][2] = 1.2; // ka
+	  pMatrix[i][3] = 1; // F1
+	  pMatrix[i][4] = 1; // F2
+	  pMatrix[i][5] = 0; // tlag1
+	  pMatrix[i][6] = 0; // tlag2
 	}
 
 	vector<double> time(nEvent);

--- a/test/unit/math/torsten/prim/generalCptModel_test.cpp
+++ b/test/unit/math/torsten/prim/generalCptModel_test.cpp
@@ -42,15 +42,15 @@ TEST(Torsten, genCpt_One_SingleDose) {
 
   double rel_err = 1e-6;
   
-  vector<Matrix<double, Eigen::Dynamic, 1> > pMatrix(1);
+  vector<vector<double> > pMatrix(1);
   pMatrix[0].resize(7);
-  pMatrix[0](0) = 10; // CL
-  pMatrix[0](1) = 80; // Vc
-  pMatrix[0](2) = 1.2; // ka 
-  pMatrix[0](3) = 1; // F1
-  pMatrix[0](4) = 1; // F2
-  pMatrix[0](5) = 0; // tlag1
-  pMatrix[0](6) = 0; // tlag2
+  pMatrix[0][0] = 10; // CL
+  pMatrix[0][1] = 80; // Vc
+  pMatrix[0][2] = 1.2; // ka
+  pMatrix[0][3] = 1; // F1
+  pMatrix[0][4] = 1; // F2
+  pMatrix[0][5] = 0; // tlag1
+  pMatrix[0][6] = 0; // tlag2
 
   vector<double> time(10);
   time[0] = 0.0;
@@ -145,17 +145,17 @@ TEST(Torsten, genCpt_One_abstime_SingleDose) {
 
   double rel_err = 1e-6;
   
-  vector<Matrix<double, Eigen::Dynamic, 1> > pMatrix(1);
+  vector<vector<double> > pMatrix(1);
   pMatrix[0].resize(9);
-  pMatrix[0](0) = 10; // CL0
-  pMatrix[0](1) = 80; // Vc
-  pMatrix[0](2) = 1.2; // ka
-  pMatrix[0](3) = 2; // CLSS
-  pMatrix[0](4) = 1; // K 
-  pMatrix[0](5) = 1; // F1
-  pMatrix[0](6) = 1; // F2
-  pMatrix[0](7) = 0; // tlag1
-  pMatrix[0](8) = 0; // tlag2
+  pMatrix[0][0] = 10; // CL0
+  pMatrix[0][1] = 80; // Vc
+  pMatrix[0][2] = 1.2; // ka
+  pMatrix[0][3] = 2; // CLSS
+  pMatrix[0][4] = 1; // K 
+  pMatrix[0][5] = 1; // F1
+  pMatrix[0][6] = 1; // F2
+  pMatrix[0][7] = 0; // tlag1
+  pMatrix[0][8] = 0; // tlag2
 
   vector<double> time(10);
   time[0] = 0.0;
@@ -212,18 +212,18 @@ TEST(Torsten, genCpOne_MultipleDoses_timePara) {
     double rel_err_bdf = 1e-4;
 
     int nEvent = 11;
-	vector<Matrix<double, Dynamic, 1> > pMatrix(nEvent);
+	vector<vector<double> > pMatrix(nEvent);
 	
 	for (int i = 0; i < nEvent; i++) {
 	  pMatrix[i].resize(7);
-	  if (i < 6) pMatrix[i](0) = 10; // CL
-	  else pMatrix[i](0) = 50; // CL is piece-wise constant
-	  pMatrix[i](1) = 80; // Vc
-	  pMatrix[i](2) = 1.2; // ka
-	  pMatrix[i](3) = 1; // F1
-	  pMatrix[i](4) = 1; // F2
-	  pMatrix[i](5) = 0; // tlag1
-	  pMatrix[i](6) = 0; // tlag2
+	  if (i < 6) pMatrix[i][0] = 10; // CL
+	  else pMatrix[i][0] = 50; // CL is piece-wise constant
+	  pMatrix[i][1] = 80; // Vc
+	  pMatrix[i][2] = 1.2; // ka
+	  pMatrix[i][3] = 1; // F1
+	  pMatrix[i][4] = 1; // F2
+	  pMatrix[i][5] = 0; // tlag1
+	  pMatrix[i][6] = 0; // tlag2
 	}
 
 	vector<double> time(nEvent);

--- a/test/unit/math/torsten/prim/linCptModel_test.cpp
+++ b/test/unit/math/torsten/prim/linCptModel_test.cpp
@@ -13,12 +13,12 @@ TEST(Torsten, LinCpt_OneSS) {
 	system << -ka, 0, ka, -k10;
 	vector<Matrix<double, Dynamic, Dynamic> > system_array(1, system); 
 
-	vector<Matrix<double, Dynamic, 1> > pMatrix(1);
+	vector<vector<double> > pMatrix(1);
 	pMatrix[0].resize(4);
-	pMatrix[0](0) = 1; // F1
-	pMatrix[0](1) = 1; // F2
-	pMatrix[0](2) = 0; // tlag1
-	pMatrix[0](3) = 0; // tlag2
+	pMatrix[0][0] = 1; // F1
+	pMatrix[0][1] = 1; // F2
+	pMatrix[0][2] = 0; // tlag1
+	pMatrix[0][3] = 0; // tlag2
 
 	vector<double> time(10);
 	time[0] = 0.0;
@@ -74,12 +74,12 @@ TEST(Torsten, linCptModel_OneSS_rate) {
 	system << -ka, 0, ka, -k10;
 	vector<Matrix<double, Dynamic, Dynamic> > system_array(1, system);
 
-	vector<Matrix<double, Dynamic, 1> > pMatrix(1);
+	vector<vector<double> > pMatrix(1);
 	pMatrix[0].resize(4);
-	pMatrix[0](0) = 1; // F1
-	pMatrix[0](1) = 1; // F2
-	pMatrix[0](2) = 0; // tlag1
-	pMatrix[0](3) = 0; // tlag2
+	pMatrix[0][0] = 1; // F1
+	pMatrix[0][1] = 1; // F2
+	pMatrix[0][2] = 0; // tlag1
+	pMatrix[0][3] = 0; // tlag2
 
 	vector<double> time(10);
 	time[0] = 0.0;
@@ -132,12 +132,12 @@ TEST(Torsten, linOne_MultipleDoses_timePara) {
 
     int nEvent = 11;
     
-	vector<Matrix<double, Dynamic, 1> > pMatrix(1);
+	vector<vector<double> > pMatrix(1);
 	pMatrix[0].resize(4);
-	pMatrix[0](0) = 1; // F1
-	pMatrix[0](1) = 1; // F2
-	pMatrix[0](2) = 0; // tlag1
-	pMatrix[0](3) = 0; // tlag2
+	pMatrix[0][0] = 1; // F1
+	pMatrix[0][1] = 1; // F2
+	pMatrix[0][2] = 0; // tlag1
+	pMatrix[0][3] = 0; // tlag2
     
     double CL_1 = 10, CL_2 = 50, Vc = 80, ka = 1.2,
       k10_1 = CL_1 / Vc, k10_2 = CL_2 / Vc;

--- a/test/unit/math/torsten/rev/PKModelOneCpt_test.cpp
+++ b/test/unit/math/torsten/rev/PKModelOneCpt_test.cpp
@@ -9,15 +9,15 @@ using Eigen::Dynamic;
 
 TEST(Torsten, PKModelOneCpt_MultipleDoses) {
 
-	vector<Matrix<AVAR, Dynamic, 1> > pMatrix(1);
+	vector<vector<AVAR> > pMatrix(1);
 	pMatrix[0].resize(7);
-	pMatrix[0](0) = 10; // CL
-	pMatrix[0](1) = 80; // Vc
-	pMatrix[0](2) = 1.2; // ka
-	pMatrix[0](3) = 1; // F1
-	pMatrix[0](4) = 1; // F2
-	pMatrix[0](5) = 0; // tlag1
-	pMatrix[0](6) = 0; // tlag2
+	pMatrix[0][0] = 10; // CL
+	pMatrix[0][1] = 80; // Vc
+	pMatrix[0][2] = 1.2; // ka
+	pMatrix[0][3] = 1; // F1
+	pMatrix[0][4] = 1; // F2
+	pMatrix[0][5] = 0; // tlag1
+	pMatrix[0][6] = 0; // tlag2
 
 	vector<double> time(10);
 	time[0] = 0.0;
@@ -65,15 +65,15 @@ TEST(Torsten, PKModelOneCpt_MultipleDoses) {
 
 TEST(Torsten, PKModelOneCpt_SS) {
 
-	vector<Matrix<AVAR, Dynamic, 1> > pMatrix(1);
+	vector<vector<AVAR> > pMatrix(1);
 	pMatrix[0].resize(7);
-	pMatrix[0](0) = 10; // CL
-	pMatrix[0](1) = 80; // Vc
-	pMatrix[0](2) = 1.2; // ka
-	pMatrix[0](3) = 1; // F1
-	pMatrix[0](4) = 1; // F2
-	pMatrix[0](5) = 0; // tlag1
-	pMatrix[0](6) = 0; // tlag2
+	pMatrix[0][0] = 10; // CL
+	pMatrix[0][1] = 80; // Vc
+	pMatrix[0][2] = 1.2; // ka
+	pMatrix[0][3] = 1; // F1
+	pMatrix[0][4] = 1; // F2
+	pMatrix[0][5] = 0; // tlag1
+	pMatrix[0][6] = 0; // tlag2
 	
 	vector<double> time(10);
 	time[0] = 0.0;
@@ -125,15 +125,15 @@ TEST(Torsten, PKModelOneCpt_SS) {
 
 TEST(Torsten, PKModelOneCpt_SS_rate) {
 	
-	vector<Matrix<AVAR, Dynamic, 1> > pMatrix(1);
+	vector<vector<AVAR> > pMatrix(1);
 	pMatrix[0].resize(7);
-	pMatrix[0](0) = 10; // CL
-	pMatrix[0](1) = 80; // Vc
-	pMatrix[0](2) = 1.2; // ka
-	pMatrix[0](3) = 1; // F1
-	pMatrix[0](4) = 1; // F2
-	pMatrix[0](5) = 0; // tlag1
-	pMatrix[0](6) = 0; // tlag2
+	pMatrix[0][0] = 10; // CL
+	pMatrix[0][1] = 80; // Vc
+	pMatrix[0][2] = 1.2; // ka
+	pMatrix[0][3] = 1; // F1
+	pMatrix[0][4] = 1; // F2
+	pMatrix[0][5] = 0; // tlag1
+	pMatrix[0][6] = 0; // tlag2
 
 	vector<double> time(10);
 	time[0] = 0.0;
@@ -188,18 +188,18 @@ TEST(Torsten, PKModelOneCpt_MultipleDoses_timePara) {
 
     int nEvent = 11;
     
-	vector<Matrix<AVAR, Dynamic, 1> > pMatrix(nEvent);
+	vector<vector<AVAR> > pMatrix(nEvent);
 	
 	for (int i = 0; i < nEvent; i++) {
 	  pMatrix[i].resize(7);
-	  if (i < 6) pMatrix[i](0) = 10; // CL
-	  else pMatrix[i](0) = 50; // CL is piece-wise constant
-	  pMatrix[i](1) = 80; // Vc
-	  pMatrix[i](2) = 1.2; // ka
-	  pMatrix[i](3) = 1; // F1
-	  pMatrix[i](4) = 1; // F2
-	  pMatrix[i](5) = 0; // tlag1
-	  pMatrix[i](6) = 0; // tlag2
+	  if (i < 6) pMatrix[i][0] = 10; // CL
+	  else pMatrix[i][0] = 50; // CL is piece-wise constant
+	  pMatrix[i][1] = 80; // Vc
+	  pMatrix[i][2] = 1.2; // ka
+	  pMatrix[i][3] = 1; // F1
+	  pMatrix[i][4] = 1; // F2
+	  pMatrix[i][5] = 0; // tlag1
+	  pMatrix[i][6] = 0; // tlag2
 	}
 
 	vector<double> time(nEvent);

--- a/test/unit/math/torsten/rev/generalCptModel_test.cpp
+++ b/test/unit/math/torsten/rev/generalCptModel_test.cpp
@@ -39,15 +39,15 @@ TEST(Torsten, genCpt_One_SingleDose) {
 
   double rel_err = 1e-6;
   
-  vector<Matrix<AVAR, Eigen::Dynamic, 1> > pMatrix(1);
+  vector<vector<AVAR> > pMatrix(1);
   pMatrix[0].resize(7);
-  pMatrix[0](0) = 10; // CL
-  pMatrix[0](1) = 80; // Vc
-  pMatrix[0](2) = 1.2; // ka 
-  pMatrix[0](3) = 1; // F1
-  pMatrix[0](4) = 1; // F2
-  pMatrix[0](5) = 0; // tlag1
-  pMatrix[0](6) = 0; // tlag2
+  pMatrix[0][0] = 10; // CL
+  pMatrix[0][1] = 80; // Vc
+  pMatrix[0][2] = 1.2; // ka
+  pMatrix[0][3] = 1; // F1
+  pMatrix[0][4] = 1; // F2
+  pMatrix[0][5] = 0; // tlag1
+  pMatrix[0][6] = 0; // tlag2
 
   vector<double> time(10);
   time[0] = 0.0;
@@ -146,17 +146,17 @@ TEST(Torsten, genCpt_One_abstime_SingleDose) {
 
   double rel_err = 1e-6;
   
-  vector<Matrix<AVAR, Eigen::Dynamic, 1> > pMatrix(1);
+  vector<vector<AVAR> > pMatrix(1);
   pMatrix[0].resize(9);
-  pMatrix[0](0) = 10; // CL0
-  pMatrix[0](1) = 80; // Vc
-  pMatrix[0](2) = 1.2; // ka
-  pMatrix[0](3) = 2; // CLSS
-  pMatrix[0](4) = 1; // K 
-  pMatrix[0](5) = 1; // F1
-  pMatrix[0](6) = 1; // F2
-  pMatrix[0](7) = 0; // tlag1
-  pMatrix[0](8) = 0; // tlag2
+  pMatrix[0][0] = 10; // CL0
+  pMatrix[0][1] = 80; // Vc
+  pMatrix[0][2] = 1.2; // ka
+  pMatrix[0][3] = 2; // CLSS
+  pMatrix[0][4] = 1; // K 
+  pMatrix[0][5] = 1; // F1
+  pMatrix[0][6] = 1; // F2
+  pMatrix[0][7] = 0; // tlag1
+  pMatrix[0][8] = 0; // tlag2
 
   vector<double> time(10);
   time[0] = 0.0;
@@ -218,18 +218,18 @@ TEST(Torsten, genCpOne_MultipleDoses_timePara) {
     double rel_err_bdf = 1e-4;
 
     int nEvent = 11;
-	vector<Matrix<AVAR, Dynamic, 1> > pMatrix(nEvent);
+	vector<vector<AVAR> > pMatrix(nEvent);
 	
 	for (int i = 0; i < nEvent; i++) {
 	  pMatrix[i].resize(7);
-	  if (i < 6) pMatrix[i](0) = 10; // CL
-	  else pMatrix[i](0) = 50; // CL is piece-wise constant
-	  pMatrix[i](1) = 80; // Vc
-	  pMatrix[i](2) = 1.2; // ka
-	  pMatrix[i](3) = 1; // F1
-	  pMatrix[i](4) = 1; // F2
-	  pMatrix[i](5) = 0; // tlag1
-	  pMatrix[i](6) = 0; // tlag2
+	  if (i < 6) pMatrix[i][0] = 10; // CL
+	  else pMatrix[i][0] = 50; // CL is piece-wise constant
+	  pMatrix[i][1] = 80; // Vc
+	  pMatrix[i][2] = 1.2; // ka
+	  pMatrix[i][3] = 1; // F1
+	  pMatrix[i][4] = 1; // F2
+	  pMatrix[i][5] = 0; // tlag1
+	  pMatrix[i][6] = 0; // tlag2
 	}
 
 	vector<double> time(nEvent);

--- a/test/unit/math/torsten/rev/linCptModel_test.cpp
+++ b/test/unit/math/torsten/rev/linCptModel_test.cpp
@@ -14,12 +14,12 @@ TEST(Torsten, LinCpt_OneSS) {
 	system << -ka, 0, ka, -k10;
 	vector<matrix_v> system_array(1, system); 
 
-	vector<Matrix<double, Dynamic, 1> > pMatrix(1);
+	vector<vector<double> > pMatrix(1);
 	pMatrix[0].resize(4);
-	pMatrix[0](0) = 1; // F1
-	pMatrix[0](1) = 1; // F2
-	pMatrix[0](2) = 0; // tlag1
-	pMatrix[0](3) = 0; // tlag2
+	pMatrix[0][0] = 1; // F1
+	pMatrix[0][1] = 1; // F2
+	pMatrix[0][2] = 0; // tlag1
+	pMatrix[0][3] = 0; // tlag2
 
 	vector<double> time(10);
 	time[0] = 0.0;
@@ -76,12 +76,12 @@ TEST(Torsten, linCptModel_OneSS_rate) {
 	system << -ka, 0, ka, -k10;
 	vector<matrix_v> system_array(1, system);
 
-	vector<Matrix<double, Dynamic, 1> > pMatrix(1);
+	vector<vector<double> > pMatrix(1);
 	pMatrix[0].resize(4);
-	pMatrix[0](0) = 1; // F1
-	pMatrix[0](1) = 1; // F2
-	pMatrix[0](2) = 0; // tlag1
-	pMatrix[0](3) = 0; // tlag2
+	pMatrix[0][0] = 1; // F1
+	pMatrix[0][1] = 1; // F2
+	pMatrix[0][2] = 0; // tlag1
+	pMatrix[0][3] = 0; // tlag2
 
 	vector<double> time(10);
 	time[0] = 0.0;
@@ -136,12 +136,12 @@ TEST(Torsten, linOne_MultipleDoses_timePara) {
 
     int nEvent = 11;
     
-	vector<Matrix<double, Dynamic, 1> > pMatrix(1);
+	vector<vector<double> > pMatrix(1);
 	pMatrix[0].resize(4);
-	pMatrix[0](0) = 1; // F1
-	pMatrix[0](1) = 1; // F2
-	pMatrix[0](2) = 0; // tlag1
-	pMatrix[0](3) = 0; // tlag2
+	pMatrix[0][0] = 1; // F1
+	pMatrix[0][1] = 1; // F2
+	pMatrix[0][2] = 0; // tlag1
+	pMatrix[0][3] = 0; // tlag2
     
     AVAR CL_1 = 10, CL_2 = 50, Vc = 80, ka = 1.2,
       k10_1 = CL_1 / Vc, k10_2 = CL_2 / Vc;


### PR DESCRIPTION
#### Submisison Checklist

- [X] Run unit tests for torsten: `./runTests.py test/unit/math/torsten`
- [ ] Run cpplint: `make cpplint` (code is not adapted yet for cpplint - see issue #5)
- [X] Declare copyright holder and open-source license: see below

#### Summary:
See issue #4 : pMatrix is now an array of array in Stan, which corresponds to a standard vector of standard vector. Formally a standard vector of eigen matrix, which made little sense, because no matrix operation was performed on the parameters and the eigen matrix was "translated" to a vector inside `ModelParameters.hpp`.  

#### Intended Effect:
More computationally efficient to store parameters in a vector.

#### How to Verify:
See C++ unit tests.
Not sure how to measure the gain in computational efficiency -- there is however one less step in the algorithm (converting the eigen matrix into a vector), so in theory, this should speed things up a bit. Most importantly perhaps, the code is cleaner and makes more sense.

#### Side Effects:
This makes the develop version of Torsten incompatible with v0.81, because the required argument for pMatrix is no longer an array of vector. This will require changes to Stan (function signatures + grammar files for functionals).


#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Metrum Research Group LLC

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

