### PR TITLE
Issue 13 overload

### DIFF
--- a/stan/math/torsten/GeneralCptModel_bdf.hpp
+++ b/stan/math/torsten/GeneralCptModel_bdf.hpp
@@ -99,4 +99,29 @@ generalCptModel_bdf(const F& f,
   return pred;
 }
 
+template <typename T0, typename T1, typename T2, typename T3, typename T4,
+  typename F>
+Eigen::Matrix <typename boost::math::tools::promote_args<T0, T1, T2, T3,
+  T4>::type, Eigen::Dynamic, Eigen::Dynamic>
+generalCptModel_bdf(const F& f,
+                    const int nCmt,
+                    const std::vector<T0>& pMatrix,
+                    const std::vector<T1>& time,
+                    const std::vector<T2>& amt,
+                    const std::vector<T3>& rate,
+                    const std::vector<T4>& ii,
+                    const std::vector<int>& evid,
+                    const std::vector<int>& cmt,
+                    const std::vector<int>& addl,
+                    const std::vector<int>& ss,
+                    double rel_tol = 1e-10,
+                    double abs_tol = 1e-10,
+                    long int max_num_steps = 1e8) {  // NOLINT(runtime/int)
+  std::vector<std::vector<T0> > vec_pMatrix(1);
+  vec_pMatrix[0] = pMatrix;
+  
+  return generalCptModel_bdf(f, nCmt,
+    vec_pMatrix, time, amt, rate, ii, evid, cmt, addl, ss);
+}                    
+
 #endif

--- a/stan/math/torsten/GeneralCptModel_bdf.hpp
+++ b/stan/math/torsten/GeneralCptModel_bdf.hpp
@@ -119,9 +119,9 @@ generalCptModel_bdf(const F& f,
                     long int max_num_steps = 1e8) {  // NOLINT(runtime/int)
   std::vector<std::vector<T0> > vec_pMatrix(1);
   vec_pMatrix[0] = pMatrix;
-  
+
   return generalCptModel_bdf(f, nCmt,
     vec_pMatrix, time, amt, rate, ii, evid, cmt, addl, ss);
-}                    
+}
 
 #endif

--- a/stan/math/torsten/GeneralCptModel_rk45.hpp
+++ b/stan/math/torsten/GeneralCptModel_rk45.hpp
@@ -100,4 +100,33 @@ generalCptModel_rk45(const F& f,
   return pred;
 }
 
+/*
+ * Overload function to allow user to pass an std::vector for 
+ * pMatrix.
+ */
+template <typename T0, typename T1, typename T2, typename T3, typename T4,
+  typename F>
+Eigen::Matrix <typename boost::math::tools::promote_args<T0, T1, T2, T3,
+  T4>::type, Eigen::Dynamic, Eigen::Dynamic>
+generalCptModel_rk45(const F& f,
+                     const int nCmt,
+                     const std::vector<T0>& pMatrix,
+                     const std::vector<T1>& time,
+                     const std::vector<T2>& amt,
+                     const std::vector<T3>& rate,
+                     const std::vector<T4>& ii,
+                     const std::vector<int>& evid,
+                     const std::vector<int>& cmt,
+                     const std::vector<int>& addl,
+                     const std::vector<int>& ss,
+                     double rel_tol = 1e-10,
+                     double abs_tol = 1e-10,
+                     long int max_num_steps = 1e8) {  // NOLINT(runtime/int)
+  std::vector<std::vector<T0> > vec_pMatrix(1);
+  vec_pMatrix[0] = pMatrix;
+  
+  return generalCptModel_rk45(f, nCmt,
+    vec_pMatrix, time, amt, rate, ii, evid, cmt, addl, ss);
+}
+
 #endif

--- a/stan/math/torsten/GeneralCptModel_rk45.hpp
+++ b/stan/math/torsten/GeneralCptModel_rk45.hpp
@@ -124,7 +124,7 @@ generalCptModel_rk45(const F& f,
                      long int max_num_steps = 1e8) {  // NOLINT(runtime/int)
   std::vector<std::vector<T0> > vec_pMatrix(1);
   vec_pMatrix[0] = pMatrix;
-  
+
   return generalCptModel_rk45(f, nCmt,
     vec_pMatrix, time, amt, rate, ii, evid, cmt, addl, ss);
 }

--- a/stan/math/torsten/PKModelOneCpt.hpp
+++ b/stan/math/torsten/PKModelOneCpt.hpp
@@ -109,7 +109,7 @@ PKModelOneCpt(const std::vector<T0>& pMatrix,
               const std::vector<int>& ss) {
   std::vector<std::vector<T0> > vec_pMatrix(1);
   vec_pMatrix[0] = pMatrix;
-  
+
   return PKModelOneCpt(vec_pMatrix, time, amt, rate, ii, evid, cmt, addl, ss);
 }
 

--- a/stan/math/torsten/PKModelOneCpt.hpp
+++ b/stan/math/torsten/PKModelOneCpt.hpp
@@ -91,4 +91,26 @@ PKModelOneCpt(const std::vector<std::vector<T0> >& pMatrix,
   return pred;
 }
 
+/*
+ * Overload function to allow user to pass an std::vector for 
+ * pMatrix.
+ */
+template <typename T0, typename T1, typename T2, typename T3, typename T4>
+Eigen::Matrix <typename boost::math::tools::promote_args<T0, T1, T2, T3,
+  T4>::type, Eigen::Dynamic, Eigen::Dynamic>
+PKModelOneCpt(const std::vector<T0>& pMatrix,
+              const std::vector<T1>& time,
+              const std::vector<T2>& amt,
+              const std::vector<T3>& rate,
+              const std::vector<T4>& ii,
+              const std::vector<int>& evid,
+              const std::vector<int>& cmt,
+              const std::vector<int>& addl,
+              const std::vector<int>& ss) {
+  std::vector<std::vector<T0> > vec_pMatrix(1);
+  vec_pMatrix[0] = pMatrix;
+  
+  return PKModelOneCpt(vec_pMatrix, time, amt, rate, ii, evid, cmt, addl, ss);
+}
+
 #endif

--- a/stan/math/torsten/PKModelTwoCpt.hpp
+++ b/stan/math/torsten/PKModelTwoCpt.hpp
@@ -110,7 +110,7 @@ PKModelTwoCpt(const std::vector<T0>& pMatrix,
               const std::vector<int>& ss) {
   std::vector<std::vector<T0> > vec_pMatrix(1);
   vec_pMatrix[0] = pMatrix;
-  
+
   return PKModelTwoCpt(vec_pMatrix, time, amt, rate, ii, evid, cmt, addl, ss);
 }
 

--- a/stan/math/torsten/PKModelTwoCpt.hpp
+++ b/stan/math/torsten/PKModelTwoCpt.hpp
@@ -92,4 +92,26 @@ PKModelTwoCpt(std::vector<std::vector<T0> >& pMatrix,
   return pred;
 }
 
+/*
+ * Overload function to allow user to pass an std::vector for 
+ * pMatrix.
+ */
+template <typename T0, typename T1, typename T2, typename T3, typename T4>
+Eigen::Matrix <typename boost::math::tools::promote_args<T0, T1, T2, T3,
+  T4>::type, Eigen::Dynamic, Eigen::Dynamic>
+PKModelTwoCpt(const std::vector<T0>& pMatrix,
+              const std::vector<T1>& time,
+              const std::vector<T2>& amt,
+              const std::vector<T3>& rate,
+              const std::vector<T4>& ii,
+              const std::vector<int>& evid,
+              const std::vector<int>& cmt,
+              const std::vector<int>& addl,
+              const std::vector<int>& ss) {
+  std::vector<std::vector<T0> > vec_pMatrix(1);
+  vec_pMatrix[0] = pMatrix;
+  
+  return PKModelTwoCpt(vec_pMatrix, time, amt, rate, ii, evid, cmt, addl, ss);
+}
+
 #endif

--- a/stan/math/torsten/linCptModel.hpp
+++ b/stan/math/torsten/linCptModel.hpp
@@ -117,4 +117,53 @@ linCptModel(const std::vector< Eigen::Matrix<T0, Eigen::Dynamic,
     vec_pMatrix, time, amt, rate, ii, evid, cmt, addl, ss);
 }
 
+template <typename T0, typename T1, typename T2, typename T3,
+  typename T4, typename T5>
+Eigen::Matrix <typename boost::math::tools::promote_args<T0, T1, T2, T3,
+  T4>::type, Eigen::Dynamic, Eigen::Dynamic>
+linCptModel(const Eigen::Matrix<T0, Eigen::Dynamic,
+              Eigen::Dynamic>& system,
+            const std::vector<std::vector<T1> >& pMatrix,
+            const std::vector<T2>& time,
+            const std::vector<T3>& amt,
+            const std::vector<T4>& rate,
+            const std::vector<T5>& ii,
+            const std::vector<int>& evid,
+            const std::vector<int>& cmt,
+            const std::vector<int>& addl,
+            const std::vector<int>& ss) {
+  std::vector<Eigen::Matrix<T0, Eigen::Dynamic,
+              Eigen::Dynamic> > vec_system(1);
+  vec_system[0] = system;
+  
+  return linCptModel(vec_system,
+    pMatrix, time, amt, rate, ii, evid, cmt, addl, ss);
+}
+
+template <typename T0, typename T1, typename T2, typename T3,
+  typename T4, typename T5>
+Eigen::Matrix <typename boost::math::tools::promote_args<T0, T1, T2, T3,
+  T4>::type, Eigen::Dynamic, Eigen::Dynamic>
+linCptModel(const Eigen::Matrix<T0, Eigen::Dynamic,
+              Eigen::Dynamic>& system,
+            const std::vector<T1>& pMatrix,
+            const std::vector<T2>& time,
+            const std::vector<T3>& amt,
+            const std::vector<T4>& rate,
+            const std::vector<T5>& ii,
+            const std::vector<int>& evid,
+            const std::vector<int>& cmt,
+            const std::vector<int>& addl,
+            const std::vector<int>& ss) {
+  std::vector<Eigen::Matrix<T0, Eigen::Dynamic,
+              Eigen::Dynamic> > vec_system(1);
+  vec_system[0] = system;
+  
+  std::vector<std::vector<T1> > vec_pMatrix(1);
+  vec_pMatrix[0] = pMatrix;
+  
+  return linCptModel(vec_system,
+    vec_pMatrix, time, amt, rate, ii, evid, cmt, addl, ss);
+}
+
 #endif

--- a/stan/math/torsten/linCptModel.hpp
+++ b/stan/math/torsten/linCptModel.hpp
@@ -112,7 +112,7 @@ linCptModel(const std::vector< Eigen::Matrix<T0, Eigen::Dynamic,
             const std::vector<int>& ss) {
   std::vector<std::vector<T1> > vec_pMatrix(1);
   vec_pMatrix[0] = pMatrix;
-  
+
   return linCptModel(system,
     vec_pMatrix, time, amt, rate, ii, evid, cmt, addl, ss);
 }
@@ -135,7 +135,7 @@ linCptModel(const Eigen::Matrix<T0, Eigen::Dynamic,
   std::vector<Eigen::Matrix<T0, Eigen::Dynamic,
               Eigen::Dynamic> > vec_system(1);
   vec_system[0] = system;
-  
+
   return linCptModel(vec_system,
     pMatrix, time, amt, rate, ii, evid, cmt, addl, ss);
 }
@@ -158,10 +158,10 @@ linCptModel(const Eigen::Matrix<T0, Eigen::Dynamic,
   std::vector<Eigen::Matrix<T0, Eigen::Dynamic,
               Eigen::Dynamic> > vec_system(1);
   vec_system[0] = system;
-  
+
   std::vector<std::vector<T1> > vec_pMatrix(1);
   vec_pMatrix[0] = pMatrix;
-  
+
   return linCptModel(vec_system,
     vec_pMatrix, time, amt, rate, ii, evid, cmt, addl, ss);
 }

--- a/stan/math/torsten/linCptModel.hpp
+++ b/stan/math/torsten/linCptModel.hpp
@@ -91,4 +91,30 @@ linCptModel(const std::vector< Eigen::Matrix<T0, Eigen::Dynamic,
   return pred;
 }
 
+/*
+ * Overload function to allow user to pass an std::vector for 
+ * pMatrix.
+ */
+template <typename T0, typename T1, typename T2, typename T3,
+  typename T4, typename T5>
+Eigen::Matrix <typename boost::math::tools::promote_args<T0, T1, T2, T3,
+  T4>::type, Eigen::Dynamic, Eigen::Dynamic>
+linCptModel(const std::vector< Eigen::Matrix<T0, Eigen::Dynamic,
+              Eigen::Dynamic> >& system,
+            const std::vector<T1>& pMatrix,
+            const std::vector<T2>& time,
+            const std::vector<T3>& amt,
+            const std::vector<T4>& rate,
+            const std::vector<T5>& ii,
+            const std::vector<int>& evid,
+            const std::vector<int>& cmt,
+            const std::vector<int>& addl,
+            const std::vector<int>& ss) {
+  std::vector<std::vector<T1> > vec_pMatrix(1);
+  vec_pMatrix[0] = pMatrix;
+  
+  return linCptModel(system,
+    vec_pMatrix, time, amt, rate, ii, evid, cmt, addl, ss);
+}
+
 #endif

--- a/test/unit/math/torsten/prim/PKModelOneCpt_test.cpp
+++ b/test/unit/math/torsten/prim/PKModelOneCpt_test.cpp
@@ -60,6 +60,59 @@ TEST(Torsten, PKModelOneCpt_MultipleDoses) {
 	expect_matrix_eq(amounts, x);
 }
 
+TEST(Torsten, PKModelOneCpt_MultipleDoses_overload) {
+
+	vector<double> pMatrix(7);
+	pMatrix[0] = 10; // CL
+	pMatrix[1] = 80; // Vc
+	pMatrix[2] = 1.2; // ka
+	pMatrix[3] = 1; // F1
+	pMatrix[4] = 1; // F2
+	pMatrix[5] = 0; // tlag1
+	pMatrix[6] = 0; // tlag2
+	
+	vector<double> time(10);
+	time[0] = 0.0;
+	for(int i = 1; i < 9; i++) time[i] = time[i - 1] + 0.25;
+	time[9] = 4.0;
+
+	vector<double> amt(10, 0);
+	amt[0] = 1000;
+	
+	vector<double> rate(10, 0);
+	
+	vector<int> cmt(10, 2);
+	cmt[0] = 1;
+	
+	vector<int> evid(10, 0);
+	evid[0] = 1;
+
+	vector<double> ii(10, 0);
+	ii[0] = 12;
+	
+	vector<int> addl(10, 0);
+	addl[0] = 14;
+	
+	vector<int> ss(10, 0);
+
+	Matrix<double, Dynamic, Dynamic> x;
+	x = PKModelOneCpt(pMatrix, time, amt, rate, ii, evid, cmt, addl, ss);
+	
+	Matrix<double, Dynamic, Dynamic> amounts(10, 2);
+	amounts << 1000.0, 0.0,
+			   740.8182, 254.97490,
+			   548.8116, 436.02020,
+			   406.5697, 562.53846,
+			   301.1942, 648.89603,
+			   223.1302, 705.72856,
+			   165.2989, 740.90816,
+			   122.4564, 760.25988,
+			   90.71795, 768.09246,
+			   8.229747, 667.87079;
+			   
+	expect_matrix_eq(amounts, x);
+}
+
 TEST(Torsten, PKModelOneCpt_SS) {
 
 	vector<vector<double> > pMatrix(1);

--- a/test/unit/math/torsten/prim/PKModelTwoCpt_test.cpp
+++ b/test/unit/math/torsten/prim/PKModelTwoCpt_test.cpp
@@ -64,6 +64,65 @@ TEST(Torsten, PKModelTwoCpt_MultipleDoses) {
 	expect_matrix_eq(amounts, x);
 }
 
+
+TEST(Torsten, PKModelTwoCpt_MultipleDoses_overload) {
+
+	vector<double> pMatrix(11);
+	pMatrix[0] = 5; // CL
+	pMatrix[1] = 8; // Q
+	pMatrix[2] = 20; // Vc
+	pMatrix[3] = 70; // Vp
+	pMatrix[4] = 1.2; // ka
+	pMatrix[5] = 1; // F1
+	pMatrix[6] = 1; // F2
+	pMatrix[7] = 1; // F3
+	pMatrix[8] = 0; // tlag1
+	pMatrix[9] = 0; // tlag2
+	pMatrix[10] = 0; // tlag3
+
+	vector<double> time(10);
+	time[0] = 0.0;
+	for(int i = 1; i < 9; i++) time[i] = time[i - 1] + 0.25;
+	time[9] = 4.0;
+
+	vector<double> amt(10, 0);
+	amt[0] = 1000;
+
+	vector<double> rate(10, 0);
+
+	vector<int> cmt(10, 2);
+	cmt[0] = 1;
+
+	vector<int> evid(10, 0);
+	evid[0] = 1;
+
+	vector<double> ii(10, 0);
+	ii[0] = 12;
+	
+	vector<int> addl(10, 0);
+	addl[0] = 14;
+	
+	vector<int> ss(10, 0);
+
+	Matrix<double, Dynamic, Dynamic> x;
+	x = PKModelTwoCpt(pMatrix, time, amt, rate, ii, evid, cmt, addl, ss);
+	
+	Matrix<double, Dynamic, Dynamic> amounts(10, 3);
+	amounts << 1000.0, 0.0, 0.0,
+			   740.818221, 238.3713, 12.75775,
+			   548.811636, 379.8439, 43.55827,
+			   406.569660, 455.3096, 83.95657,
+			   301.194212, 486.6965, 128.32332,
+			   223.130160, 489.4507, 173.01118,
+			   165.298888, 474.3491, 215.75441,
+			   122.456428, 448.8192, 255.23842,
+			   90.717953, 417.9001, 290.79297,
+			   8.229747, 200.8720, 441.38985;
+			   
+	expect_matrix_eq(amounts, x);
+}
+
+
 TEST(Torsten, PKModelTwoCpt_SS) {
 
 	vector<vector<double> > pMatrix(1);

--- a/test/unit/math/torsten/prim/generalCptModel_test.cpp
+++ b/test/unit/math/torsten/prim/generalCptModel_test.cpp
@@ -104,6 +104,72 @@ TEST(Torsten, genCpt_One_SingleDose) {
   expect_near_matrix_eq(amounts, x_bdf, rel_err);
 }
 
+TEST(Torsten, genCpt_One_SingleDose_overload) {
+  using std::vector;
+  using Eigen::Matrix;
+  using Eigen::Dynamic;
+
+  double rel_err = 1e-6;
+  
+  vector<double> pMatrix(7);
+  pMatrix[0] = 10; // CL
+  pMatrix[1] = 80; // Vc
+  pMatrix[2] = 1.2; // ka
+  pMatrix[3] = 1; // F1
+  pMatrix[4] = 1; // F2
+  pMatrix[5] = 0; // tlag1
+  pMatrix[6] = 0; // tlag2
+
+  vector<double> time(10);
+  time[0] = 0.0;
+  for(int i = 1; i < 9; i++) time[i] = time[i - 1] + 0.25;
+  time[9] = 4.0;
+
+  vector<double> amt(10, 0);
+  amt[0] = 1000;
+	
+  vector<double> rate(10, 0);
+	
+  vector<int> cmt(10, 2);
+  cmt[0] = 1;
+	
+  vector<int> evid(10, 0);
+  evid[0] = 1;
+
+  vector<double> ii(10, 0);
+  ii[0] = 12;
+	
+  vector<int> addl(10, 0);
+  addl[0] = 14;
+	
+  vector<int> ss(10, 0);
+
+  Matrix<double, Eigen::Dynamic, Eigen::Dynamic> x_rk45;
+  x_rk45 = generalCptModel_rk45(oneCptModelODE_functor(), 2,
+                                pMatrix, time, amt, rate, ii, evid, cmt, addl, ss,
+                                1e-8, 1e-8, 1e8);
+
+  Matrix<double, Eigen::Dynamic, Eigen::Dynamic> x_bdf;
+  x_bdf = generalCptModel_bdf(oneCptModelODE_functor(), 2,
+                              pMatrix, time, amt, rate, ii, evid, cmt, addl, ss,
+                              1e-8, 1e-8, 1e8);
+	
+  Matrix<double, Dynamic, Dynamic> amounts(10, 2);
+  amounts << 1000.0, 0.0,
+	  	     740.8182, 254.97490,
+			 548.8116, 436.02020,
+			 406.5697, 562.53846,
+			 301.1942, 648.89603,
+			 223.1302, 705.72856,
+			 165.2989, 740.90816,
+			 122.4564, 760.25988,
+			 90.71795, 768.09246,
+			 8.229747, 667.87079;
+
+  expect_near_matrix_eq(amounts, x_rk45, rel_err);
+  expect_near_matrix_eq(amounts, x_bdf, rel_err);
+}
+
 template <typename T0, typename T1, typename T2, typename T3>
 inline
 std::vector<typename boost::math::tools::promote_args<T0, T1, T2, T3>::type>

--- a/test/unit/math/torsten/prim/linCptModel_test.cpp
+++ b/test/unit/math/torsten/prim/linCptModel_test.cpp
@@ -66,6 +66,64 @@ TEST(Torsten, LinCpt_OneSS) {
 	}
 }
 
+TEST(Torsten, LinCpt_OneSS_overload) {
+
+	double CL = 10, Vc = 80, ka = 1.2, k10 = CL / Vc;
+	Matrix<double, Dynamic, Dynamic> system(2, 2);
+	system << -ka, 0, ka, -k10;
+	vector<Matrix<double, Dynamic, Dynamic> > system_array(1, system); 
+
+	vector<double> pMatrix(4);
+	pMatrix[0] = 1; // F1
+	pMatrix[1] = 1; // F2
+	pMatrix[2] = 0; // tlag1
+	pMatrix[3] = 0; // tlag2
+
+	vector<double> time(10);
+	time[0] = 0.0;
+	time[1] = 0.0;
+	for(int i = 2; i < 10; i++) time[i] = time[i - 1] + 5;
+
+	vector<double> amt(10, 0);
+	amt[0] = 1200;
+
+	vector<double> rate(10, 0);
+
+	vector<int> cmt(10, 2);
+	cmt[0] = 1;
+
+	vector<int> evid(10, 0);
+	evid[0] = 1;
+
+	vector<double> ii(10, 0);
+	ii[0] = 12;
+
+	vector<int> addl(10, 0);
+	addl[0] = 10;
+
+	vector<int> ss(10, 0);
+	ss[0] = 1;
+
+	Matrix<double, Dynamic, Dynamic> x;
+	x = linCptModel(system_array, pMatrix, time, amt, rate, ii, evid, cmt, addl, ss);
+
+	Matrix<double, Dynamic, Dynamic> amounts(10, 2);
+	amounts << 1200.0, 384.7363,
+	           1200.0, 384.7363,
+	           2.974504, 919.6159,
+	           7.373062e-3, 494.0040,
+	           3.278849e+1, 1148.4725,
+	           8.127454e-2, 634.2335,
+	           3.614333e+2, 1118.2043,
+	           8.959035e-1, 813.4883,
+	           2.220724e-3, 435.9617,
+	           9.875702, 1034.7998;
+
+	for(int i = 0; i < amounts.rows(); i++) {
+		EXPECT_NEAR(amounts(i, 0), x(i, 0), std::max(amounts(i, 0), x(i, 0)) * 1e-6);
+		EXPECT_NEAR(amounts(i, 1), x(i, 1), std::max(amounts(i, 1), x(i, 1)) * 1e-6);
+	}
+}
 
 TEST(Torsten, linCptModel_OneSS_rate) {
 

--- a/test/unit/math/torsten/prim/linCptModel_test.cpp
+++ b/test/unit/math/torsten/prim/linCptModel_test.cpp
@@ -66,18 +66,19 @@ TEST(Torsten, LinCpt_OneSS) {
 	}
 }
 
-TEST(Torsten, LinCpt_OneSS_overload) {
+TEST(Torsten, LinCpt_OneSS_overloads) {
 
 	double CL = 10, Vc = 80, ka = 1.2, k10 = CL / Vc;
 	Matrix<double, Dynamic, Dynamic> system(2, 2);
 	system << -ka, 0, ka, -k10;
 	vector<Matrix<double, Dynamic, Dynamic> > system_array(1, system); 
 
-	vector<double> pMatrix(4);
-	pMatrix[0] = 1; // F1
-	pMatrix[1] = 1; // F2
-	pMatrix[2] = 0; // tlag1
-	pMatrix[3] = 0; // tlag2
+	vector<vector<double> > pMatrix(1);
+	pMatrix[0].resize(4);
+	pMatrix[0][0] = 1; // F1
+	pMatrix[0][1] = 1; // F2
+	pMatrix[0][2] = 0; // tlag1
+	pMatrix[0][3] = 0; // tlag2
 
 	vector<double> time(10);
 	time[0] = 0.0;
@@ -104,8 +105,13 @@ TEST(Torsten, LinCpt_OneSS_overload) {
 	vector<int> ss(10, 0);
 	ss[0] = 1;
 
-	Matrix<double, Dynamic, Dynamic> x;
-	x = linCptModel(system_array, pMatrix, time, amt, rate, ii, evid, cmt, addl, ss);
+	Matrix<double, Dynamic, Dynamic> x1, x2, x3;
+	x1 = linCptModel(system_array, pMatrix[0],
+	  time, amt, rate, ii, evid, cmt, addl, ss);
+	x2 = linCptModel(system_array[0], pMatrix,
+	  time, amt, rate, ii, evid, cmt, addl, ss);
+	x3 = linCptModel(system_array[0], pMatrix[0],
+	  time, amt, rate, ii, evid, cmt, addl, ss);
 
 	Matrix<double, Dynamic, Dynamic> amounts(10, 2);
 	amounts << 1200.0, 384.7363,
@@ -119,9 +125,21 @@ TEST(Torsten, LinCpt_OneSS_overload) {
 	           2.220724e-3, 435.9617,
 	           9.875702, 1034.7998;
 
-	for(int i = 0; i < amounts.rows(); i++) {
-		EXPECT_NEAR(amounts(i, 0), x(i, 0), std::max(amounts(i, 0), x(i, 0)) * 1e-6);
-		EXPECT_NEAR(amounts(i, 1), x(i, 1), std::max(amounts(i, 1), x(i, 1)) * 1e-6);
+	for(int i = 0; i < amounts.rows(); i++) {	
+		EXPECT_NEAR(amounts(i, 0), x1(i, 0),
+		  std::max(amounts(i, 0), x1(i, 0)) * 1e-6);
+		EXPECT_NEAR(amounts(i, 1), x1(i, 1),
+		  std::max(amounts(i, 1), x1(i, 1)) * 1e-6);
+		  
+		EXPECT_NEAR(amounts(i, 0), x2(i, 0),
+		  std::max(amounts(i, 0), x2(i, 0)) * 1e-6);
+		EXPECT_NEAR(amounts(i, 1), x2(i, 1),
+		  std::max(amounts(i, 1), x2(i, 1)) * 1e-6);
+
+		EXPECT_NEAR(amounts(i, 0), x3(i, 0),
+		  std::max(amounts(i, 0), x3(i, 0)) * 1e-6);
+		EXPECT_NEAR(amounts(i, 1), x3(i, 1),
+		  std::max(amounts(i, 1), x3(i, 1)) * 1e-6);
 	}
 }
 

--- a/test/unit/math/torsten/rev/PKModelOneCpt_test.cpp
+++ b/test/unit/math/torsten/rev/PKModelOneCpt_test.cpp
@@ -63,6 +63,61 @@ TEST(Torsten, PKModelOneCpt_MultipleDoses) {
       EXPECT_FLOAT_EQ(amounts(i, j), x(i, j).val());
 }
 
+TEST(Torsten, PKModelOneCpt_MultipleDoses_overload) {
+
+	vector<AVAR> pMatrix(7);
+	pMatrix[0] = 10; // CL
+	pMatrix[1] = 80; // Vc
+	pMatrix[2] = 1.2; // ka
+	pMatrix[3] = 1; // F1
+	pMatrix[4] = 1; // F2
+	pMatrix[5] = 0; // tlag1
+	pMatrix[6] = 0; // tlag2
+
+	vector<double> time(10);
+	time[0] = 0.0;
+	for(int i = 1; i < 9; i++) time[i] = time[i - 1] + 0.25;
+	time[9] = 4.0;
+
+	vector<double> amt(10, 0);
+	amt[0] = 1000;
+	
+	vector<double> rate(10, 0);
+	
+	vector<int> cmt(10, 2);
+	cmt[0] = 1;
+	
+	vector<int> evid(10, 0);
+	evid[0] = 1;
+
+	vector<double> ii(10, 0);
+	ii[0] = 12;
+	
+	vector<int> addl(10, 0);
+	addl[0] = 14;
+	
+	vector<int> ss(10, 0);
+
+	stan::math::matrix_v x;
+	x = PKModelOneCpt(pMatrix, time, amt, rate, ii, evid, cmt, addl, ss);
+	
+	Matrix<double, Dynamic, Dynamic> amounts(10, 2);
+	amounts << 1000.0, 0.0,
+			   740.8182, 254.97490,
+			   548.8116, 436.02020,
+			   406.5697, 562.53846,
+			   301.1942, 648.89603,
+			   223.1302, 705.72856,
+			   165.2989, 740.90816,
+			   122.4564, 760.25988,
+			   90.71795, 768.09246,
+			   8.229747, 667.87079;
+   
+  for (size_t i = 0; i < amounts.rows(); i++)
+    for (size_t j = 0; j < amounts.cols(); j++)
+      EXPECT_FLOAT_EQ(amounts(i, j), x(i, j).val());
+}
+
 TEST(Torsten, PKModelOneCpt_SS) {
 
 	vector<vector<AVAR> > pMatrix(1);

--- a/test/unit/math/torsten/rev/PKModelTwoCpt_test.cpp
+++ b/test/unit/math/torsten/rev/PKModelTwoCpt_test.cpp
@@ -69,6 +69,66 @@ TEST(Torsten, PKModelTwoCpt_MultipleDoses) {
 }
 
 
+TEST(Torsten, PKModelTwoCpt_MultipleDoses_overload) {
+
+	vector<AVAR> pMatrix(11);
+	pMatrix[0] = 5; // CL
+	pMatrix[1] = 8; // Q
+	pMatrix[2] = 20; // Vc
+	pMatrix[3] = 70; // Vp
+	pMatrix[4] = 1.2; // ka
+	pMatrix[5] = 1; // F1
+	pMatrix[6] = 1; // F2
+	pMatrix[7] = 1; // F3
+	pMatrix[8] = 0; // tlag1
+	pMatrix[9] = 0; // tlag2
+	pMatrix[10] = 0; // tlag3
+
+	vector<double> time(10);
+	time[0] = 0.0;
+	for(int i = 1; i < 9; i++) time[i] = time[i - 1] + 0.25;
+	time[9] = 4.0;
+
+	vector<double> amt(10, 0);
+	amt[0] = 1000;
+
+	vector<double> rate(10, 0);
+
+	vector<int> cmt(10, 2);
+	cmt[0] = 1;
+
+	vector<int> evid(10, 0);
+	evid[0] = 1;
+
+	vector<double> ii(10, 0);
+	ii[0] = 12;
+	
+	vector<int> addl(10, 0);
+	addl[0] = 14;
+	
+	vector<int> ss(10, 0);
+
+	stan::math::matrix_v x;
+	x = PKModelTwoCpt(pMatrix, time, amt, rate, ii, evid, cmt, addl, ss);
+	
+	Matrix<double, Dynamic, Dynamic> amounts(10, 3);
+	amounts << 1000.0, 0.0, 0.0,
+			   740.818221, 238.3713, 12.75775,
+			   548.811636, 379.8439, 43.55827,
+			   406.569660, 455.3096, 83.95657,
+			   301.194212, 486.6965, 128.32332,
+			   223.130160, 489.4507, 173.01118,
+			   165.298888, 474.3491, 215.75441,
+			   122.456428, 448.8192, 255.23842,
+			   90.717953, 417.9001, 290.79297,
+			   8.229747, 200.8720, 441.38985;
+			   
+	for (size_t i = 0; i < amounts.rows(); i++)
+      for (size_t j = 0; j < amounts.cols(); j++)
+        EXPECT_FLOAT_EQ(amounts(i, j), x(i, j).val());
+}
+
+
 TEST(Torsten, PKModelTwoCpt_SS) {
 
 	vector<vector<AVAR> > pMatrix(1);

--- a/test/unit/math/torsten/rev/PKModelTwoCpt_test.cpp
+++ b/test/unit/math/torsten/rev/PKModelTwoCpt_test.cpp
@@ -110,7 +110,7 @@ TEST(Torsten, PKModelTwoCpt_MultipleDoses_overload) {
 
 	stan::math::matrix_v x;
 	x = PKModelTwoCpt(pMatrix, time, amt, rate, ii, evid, cmt, addl, ss);
-	
+
 	Matrix<double, Dynamic, Dynamic> amounts(10, 3);
 	amounts << 1000.0, 0.0, 0.0,
 			   740.818221, 238.3713, 12.75775,

--- a/test/unit/math/torsten/rev/generalCptModel_test.cpp
+++ b/test/unit/math/torsten/rev/generalCptModel_test.cpp
@@ -106,6 +106,77 @@ TEST(Torsten, genCpt_One_SingleDose) {
   }
 }
 
+TEST(Torsten, genCpt_One_SingleDose_overload) {
+  using std::vector;
+  using Eigen::Matrix;
+  using Eigen::Dynamic;
+
+  double rel_err = 1e-6;
+  
+  vector<AVAR> pMatrix(7);
+  pMatrix[0] = 10; // CL
+  pMatrix[1] = 80; // Vc
+  pMatrix[2] = 1.2; // ka
+  pMatrix[3] = 1; // F1
+  pMatrix[4] = 1; // F2
+  pMatrix[5] = 0; // tlag1
+  pMatrix[6] = 0; // tlag2
+
+  vector<double> time(10);
+  time[0] = 0.0;
+  for(int i = 1; i < 9; i++) time[i] = time[i - 1] + 0.25;
+  time[9] = 4.0;
+
+  vector<double> amt(10, 0);
+  amt[0] = 1000;
+	
+  vector<double> rate(10, 0);
+	
+  vector<int> cmt(10, 2);
+  cmt[0] = 1;
+	
+  vector<int> evid(10, 0);
+  evid[0] = 1;
+
+  vector<double> ii(10, 0);
+  ii[0] = 12;
+	
+  vector<int> addl(10, 0);
+  addl[0] = 14;
+	
+  vector<int> ss(10, 0);
+
+  stan::math::matrix_v x_rk45;
+  x_rk45 = generalCptModel_rk45(oneCptModelODE_functor(), 2,
+                                pMatrix, time, amt, rate, ii, evid, cmt, addl, ss,
+                                1e-8, 1e-8, 1e8);
+
+  stan::math::matrix_v x_bdf;
+  x_bdf = generalCptModel_bdf(oneCptModelODE_functor(), 2,
+                              pMatrix, time, amt, rate, ii, evid, cmt, addl, ss,
+                              1e-8, 1e-8, 1e8);
+	
+  Matrix<double, Dynamic, Dynamic> amounts(10, 2);
+  amounts << 1000.0, 0.0,
+	  	     740.8182, 254.97490,
+			 548.8116, 436.02020,
+			 406.5697, 562.53846,
+			 301.1942, 648.89603,
+			 223.1302, 705.72856,
+			 165.2989, 740.90816,
+			 122.4564, 760.25988,
+			 90.71795, 768.09246,
+			 8.229747, 667.87079;
+
+  for (size_t i = 0; i < amounts.rows(); i++)
+    for (size_t j = 0; j < amounts.cols(); j++) {
+      EXPECT_NEAR(amounts(i, j), x_rk45(i, j).val(),
+        std::max(amounts(i, j), x_rk45(i, j).val()) * rel_err);
+      EXPECT_NEAR(amounts(i, j), x_bdf(i, j).val(),
+        std::max(amounts(i, j), x_bdf(i, j).val()) * rel_err);
+  }
+}
+
 template <typename T0, typename T1, typename T2, typename T3>
 inline
 std::vector<typename boost::math::tools::promote_args<T0, T1, T2, T3>::type>

--- a/test/unit/math/torsten/rev/linCptModel_test.cpp
+++ b/test/unit/math/torsten/rev/linCptModel_test.cpp
@@ -69,18 +69,19 @@ TEST(Torsten, LinCpt_OneSS) {
 	}
 }
 
-TEST(Torsten, LinCpt_OneSS_overload) {
+TEST(Torsten, LinCpt_OneSS_overloads) {
 
 	AVAR CL = 10, Vc = 80, ka = 1.2, k10 = CL / Vc;
 	matrix_v system(2, 2);
 	system << -ka, 0, ka, -k10;
 	vector<matrix_v> system_array(1, system); 
 
-	vector<double> pMatrix(4);
-	pMatrix[0] = 1; // F1
-	pMatrix[1] = 1; // F2
-	pMatrix[2] = 0; // tlag1
-	pMatrix[3] = 0; // tlag2
+	vector<vector<double> > pMatrix(1);
+	pMatrix[0].resize(4);
+	pMatrix[0][0] = 1; // F1
+	pMatrix[0][1] = 1; // F2
+	pMatrix[0][2] = 0; // tlag1
+	pMatrix[0][3] = 0; // tlag2
 
 	vector<double> time(10);
 	time[0] = 0.0;
@@ -107,8 +108,13 @@ TEST(Torsten, LinCpt_OneSS_overload) {
 	vector<int> ss(10, 0);
 	ss[0] = 1;
 
-	matrix_v x;
-	x = linCptModel(system_array, pMatrix, time, amt, rate, ii, evid, cmt, addl, ss);
+	matrix_v x1, x2, x3;
+	x1 = linCptModel(system_array, pMatrix[0],
+	  time, amt, rate, ii, evid, cmt, addl, ss);
+	x2 = linCptModel(system_array[0], pMatrix,
+	  time, amt, rate, ii, evid, cmt, addl, ss);
+	x3 = linCptModel(system_array[0], pMatrix[0],
+	  time, amt, rate, ii, evid, cmt, addl, ss);
 
 	Matrix<double, Dynamic, Dynamic> amounts(10, 2);
 	amounts << 1200.0, 384.7363,
@@ -123,10 +129,20 @@ TEST(Torsten, LinCpt_OneSS_overload) {
 	           9.875702, 1034.7998;
 
 	for(int i = 0; i < amounts.rows(); i++) {
-		EXPECT_NEAR(amounts(i, 0), x(i, 0).val(),
-		  std::max(amounts(i, 0), x(i, 0).val()) * 1e-6);
-		EXPECT_NEAR(amounts(i, 1), x(i, 1).val(),
-		  std::max(amounts(i, 1), x(i, 1).val()) * 1e-6);
+		EXPECT_NEAR(amounts(i, 0), x1(i, 0).val(),
+		  std::max(amounts(i, 0), x1(i, 0).val()) * 1e-6);
+		EXPECT_NEAR(amounts(i, 1), x1(i, 1).val(),
+		  std::max(amounts(i, 1), x1(i, 1).val()) * 1e-6);
+		  
+		EXPECT_NEAR(amounts(i, 0), x2(i, 0).val(),
+		  std::max(amounts(i, 0), x2(i, 0).val()) * 1e-6);
+		EXPECT_NEAR(amounts(i, 1), x2(i, 1).val(),
+		  std::max(amounts(i, 1), x2(i, 1).val()) * 1e-6);
+
+		EXPECT_NEAR(amounts(i, 0), x3(i, 0).val(),
+		  std::max(amounts(i, 0), x3(i, 0).val()) * 1e-6);
+		EXPECT_NEAR(amounts(i, 1), x3(i, 1).val(),
+		  std::max(amounts(i, 1), x3(i, 1).val()) * 1e-6);
 	}
 }
 

--- a/test/unit/math/torsten/rev/linCptModel_test.cpp
+++ b/test/unit/math/torsten/rev/linCptModel_test.cpp
@@ -69,6 +69,67 @@ TEST(Torsten, LinCpt_OneSS) {
 	}
 }
 
+TEST(Torsten, LinCpt_OneSS_overload) {
+
+	AVAR CL = 10, Vc = 80, ka = 1.2, k10 = CL / Vc;
+	matrix_v system(2, 2);
+	system << -ka, 0, ka, -k10;
+	vector<matrix_v> system_array(1, system); 
+
+	vector<double> pMatrix(4);
+	pMatrix[0] = 1; // F1
+	pMatrix[1] = 1; // F2
+	pMatrix[2] = 0; // tlag1
+	pMatrix[3] = 0; // tlag2
+
+	vector<double> time(10);
+	time[0] = 0.0;
+	time[1] = 0.0;
+	for(int i = 2; i < 10; i++) time[i] = time[i - 1] + 5;
+
+	vector<double> amt(10, 0);
+	amt[0] = 1200;
+
+	vector<double> rate(10, 0);
+
+	vector<int> cmt(10, 2);
+	cmt[0] = 1;
+
+	vector<int> evid(10, 0);
+	evid[0] = 1;
+
+	vector<double> ii(10, 0);
+	ii[0] = 12;
+
+	vector<int> addl(10, 0);
+	addl[0] = 10;
+
+	vector<int> ss(10, 0);
+	ss[0] = 1;
+
+	matrix_v x;
+	x = linCptModel(system_array, pMatrix, time, amt, rate, ii, evid, cmt, addl, ss);
+
+	Matrix<double, Dynamic, Dynamic> amounts(10, 2);
+	amounts << 1200.0, 384.7363,
+	           1200.0, 384.7363,
+	           2.974504, 919.6159,
+	           7.373062e-3, 494.0040,
+	           3.278849e+1, 1148.4725,
+	           8.127454e-2, 634.2335,
+	           3.614333e+2, 1118.2043,
+	           8.959035e-1, 813.4883,
+	           2.220724e-3, 435.9617,
+	           9.875702, 1034.7998;
+
+	for(int i = 0; i < amounts.rows(); i++) {
+		EXPECT_NEAR(amounts(i, 0), x(i, 0).val(),
+		  std::max(amounts(i, 0), x(i, 0).val()) * 1e-6);
+		EXPECT_NEAR(amounts(i, 1), x(i, 1).val(),
+		  std::max(amounts(i, 1), x(i, 1).val()) * 1e-6);
+	}
+}
+
 TEST(Torsten, linCptModel_OneSS_rate) {
 
 	AVAR CL = 10, Vc = 80, ka = 1.2, k10 = CL / Vc;


### PR DESCRIPTION
#### Submisison Checklist

- [x] Run unit tests: `./runTests.py test/unit/torsten`
- [x] Run cpplint: `make cpplint`
- [x] Declare copyright holder and open-source license: see below

#### Summary:
Overload torsten functions to allow users to:
- pass in an `std::vector` for pMatrix (instead of a 2D vector of length 1 x n).
- pass in an `Eigen::Matrix` for system (instead of a vector of matrix of length 1 x n x n) for `linCptModel`. 

#### Intended Effect:
Ease for the users.

#### How to Verify:
Each unit test has a test for the overloaded function.

#### Documentation:
Need to update the user manual.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Metrum Research Group LCC

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
