### PR TITLE
Issue 16 autodiff tests

### DIFF
--- a/stan/math/prim/mat/fun/matrix_exp.hpp
+++ b/stan/math/prim/mat/fun/matrix_exp.hpp
@@ -7,7 +7,7 @@
 
 namespace stan {
     namespace math {
-        
+
         /**
          * Return the matrix exponential of the input
          * matrix.
@@ -23,7 +23,7 @@ namespace stan {
         matrix_exp(const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> A) {
             check_nonzero_size("matrix_exp", "input matrix", A);
             check_square("matrix_exp", "input matrix", A);
-            
+
             return (A.cols() == 2
                     && square(value_of(A(0, 0)) - value_of(A(1, 1)))
                     + 4 * value_of(A(0, 1)) * value_of(A(1, 0)) > 0)

--- a/stan/math/prim/mat/fun/matrix_exp_2x2.hpp
+++ b/stan/math/prim/mat/fun/matrix_exp_2x2.hpp
@@ -19,7 +19,7 @@ namespace stan {
         template <typename T>
         Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
         matrix_exp_2x2(
-          const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& A) {            
+          const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& A) {
             T a = A(0, 0), b = A(0, 1), c = A(1, 0), d = A(1, 1), delta;
             delta = sqrt(square(a - d) + 4 * b * c);
 

--- a/stan/math/torsten/PKModel/Event.hpp
+++ b/stan/math/torsten/PKModel/Event.hpp
@@ -44,7 +44,7 @@ private:
   T_rate rate;
   T_ii ii;
   int evid, cmt, addl, ss;
-  bool keep, isnew, lagEvent;
+  bool keep, isnew;
 
 public:
   Event() {
@@ -57,7 +57,6 @@ public:
     ss = 0;
     keep = false;
     isnew = false;
-    lagEvent = false;
   }
 
   Event(T_time p_time, T_amt p_amt, T_rate p_rate, T_ii p_ii, int p_evid,
@@ -72,7 +71,6 @@ public:
     ss = p_ss;
     keep = p_keep;
     isnew = p_isnew;
-    lagEvent = false;
   }
 
   /**
@@ -93,7 +91,6 @@ public:
     newEvent.ss = p_ss;
     newEvent.keep = p_keep;
     newEvent.isnew = p_isnew;
-    newEvent.lagEvent = false;
     return newEvent;
   }
 
@@ -108,7 +105,6 @@ public:
   int get_ss() { return ss; }
   bool get_keep() { return keep; }
   bool get_isnew() { return isnew; }
-  bool get_lagEvent() { return lagEvent; }
 
   void Print() {
     std::cout << time << " "
@@ -120,8 +116,7 @@ public:
               << addl << " "
               << ss << " "
               << keep << " "
-              << isnew << " "
-              << lagEvent << std::endl;
+              << isnew << std::endl;
   }
 
   // declare friends
@@ -233,11 +228,7 @@ public:
   struct by_time {
     bool operator()(const Event<T_time, T_amt, T_rate, T_ii> &a,
       const Event<T_time, T_amt, T_rate, T_ii> &b) {
-      bool sorted;
-      if (a.time == b.time)
-        sorted = a.lagEvent > b.lagEvent;
-      else sorted = a.time < b.time;
-      return sorted;
+        return a.time < b.time;
     }
   };
 
@@ -301,19 +292,18 @@ public:
                                           // event or 0, if the parameters
                                           // are constant.
 
-          // if ((cmt == tlagCmts[j])
-          //  && (Parameters.GetValue(ipar, tlagIndexes[j]) != 0)) {
-          if (cmt == tlagCmts[j]) {
+          if ((cmt == tlagCmts[j])
+            && (Parameters.GetValue(ipar, tlagIndexes[j]) != 0)) {
+          // if (cmt == tlagCmts[j]) {
             newEvent = GetEvent(i);
             newEvent.time += Parameters.GetValue(ipar, tlagIndexes[j]);
             newEvent.keep = false;
             newEvent.isnew = true;
-            // newEvent.lagEvent = false;
             // newEvent.evid = 2; // - CHECK
             InsertEvent(newEvent);
 
             Events[i].evid = 2;
-            // Events[i].time += evid;
+            // Events[i].time += evid; // - CHECK
             // The above statement changes events so that CleanEvents does
             // not return an object identical to the original. - CHECK
           }

--- a/stan/math/torsten/PKModel/ModelParameters.hpp
+++ b/stan/math/torsten/PKModel/ModelParameters.hpp
@@ -9,7 +9,6 @@
 
 template<typename T_time, typename T_parameters, typename T_system>
   class ModelParameterHistory;
-
 /**
  * The ModelParameters class defines objects that contain the parameters of a
  * compartment model at a given time.
@@ -43,6 +42,7 @@ public:
     return RealParameters.size();  // FIX ME - account for parameters in K?
   }
 
+  // FIX ME - probably do not need this function
   Eigen::Matrix<T_system, Eigen::Dynamic, Eigen::Dynamic> RateMatrix() const {
     return K;
   }

--- a/stan/math/torsten/PKModelOneCpt.hpp
+++ b/stan/math/torsten/PKModelOneCpt.hpp
@@ -92,8 +92,7 @@ PKModelOneCpt(const std::vector<std::vector<T0> >& pMatrix,
 }
 
 /*
- * Overload function to allow user to pass an std::vector for 
- * pMatrix.
+ * Overload function to allow user to pass an std::vector for pMatrix.
  */
 template <typename T0, typename T1, typename T2, typename T3, typename T4>
 Eigen::Matrix <typename boost::math::tools::promote_args<T0, T1, T2, T3,

--- a/stan/math/torsten/PKModelOneCpt.hpp
+++ b/stan/math/torsten/PKModelOneCpt.hpp
@@ -88,6 +88,8 @@ PKModelOneCpt(const std::vector<std::vector<T0> >& pMatrix,
   pred = Pred(pMatrix, time, amt, rate, ii, evid, cmt, addl, ss, model,
     dummy_ode(), dummy_systems);
 
+  //std::cout << pred << std::endl;
+
   return pred;
 }
 

--- a/stan/math/torsten/PKModelOneCpt.hpp
+++ b/stan/math/torsten/PKModelOneCpt.hpp
@@ -88,8 +88,6 @@ PKModelOneCpt(const std::vector<std::vector<T0> >& pMatrix,
   pred = Pred(pMatrix, time, amt, rate, ii, evid, cmt, addl, ss, model,
     dummy_ode(), dummy_systems);
 
-  //std::cout << pred << std::endl;
-
   return pred;
 }
 

--- a/test/unit/math/torsten/prim/PKModelOneCpt_test.cpp
+++ b/test/unit/math/torsten/prim/PKModelOneCpt_test.cpp
@@ -18,7 +18,7 @@ TEST(Torsten, PKModelOneCpt_MultipleDoses) {
 	pMatrix[0][4] = 1; // F2
 	pMatrix[0][5] = 0; // tlag1
 	pMatrix[0][6] = 0; // tlag2
-	
+
 	vector<double> time(10);
 	time[0] = 0; // SHOULD BE 0
 	for(int i = 1; i < 9; i++) time[i] = time[i - 1] + 0.25;
@@ -26,21 +26,21 @@ TEST(Torsten, PKModelOneCpt_MultipleDoses) {
 
 	vector<double> amt(10, 0);
 	amt[0] = 1000;
-	
+
 	vector<double> rate(10, 0);
-	
+
 	vector<int> cmt(10, 2);
 	cmt[0] = 1;
-	
+
 	vector<int> evid(10, 0);
 	evid[0] = 1;
 
 	vector<double> ii(10, 0);
 	ii[0] = 12;
-	
+
 	vector<int> addl(10, 0);
 	addl[0] = 14;
-	
+
 	vector<int> ss(10, 0);
 
 	Matrix<double, Dynamic, Dynamic> x;
@@ -64,7 +64,7 @@ TEST(Torsten, PKModelOneCpt_MultipleDoses) {
     test_PKModelOneCpt(pMatrix, time, amt, rate, ii, evid, cmt, addl, ss,
                        1e-8, 1e-4);
 }
-/*
+
 TEST(Torsten, PKModelOneCpt_MultipleDoses_overload) {
 
 	vector<double> pMatrix(7);
@@ -116,6 +116,10 @@ TEST(Torsten, PKModelOneCpt_MultipleDoses_overload) {
 			   8.229747, 667.87079;
 			   
 	expect_matrix_eq(amounts, x);
+
+	// Test AutoDiff against FiniteDiff
+    test_PKModelOneCpt(pMatrix, time, amt, rate, ii, evid, cmt, addl, ss,
+                       1e-8, 1e-4);
 }
 
 TEST(Torsten, PKModelOneCpt_SS) {
@@ -176,8 +180,8 @@ TEST(Torsten, PKModelOneCpt_SS) {
 	}
 
     // Test auto-diff
-    // test_PKModelOneCpt(pMatrix, time, amt, rate, ii, evid, cmt, addl, ss,
-    //                   1e-8, 1e-4);
+    test_PKModelOneCpt(pMatrix, time, amt, rate, ii, evid, cmt, addl, ss,
+                       1e-8, 1e-4);
 }
 
 TEST(Torsten, PKModelOneCpt_SS_rate) {
@@ -237,6 +241,10 @@ TEST(Torsten, PKModelOneCpt_SS_rate) {
 		EXPECT_NEAR(amounts(i, 0), x(i, 0), std::max(amounts(i, 0), x(i, 0)) * 1e-6);
 		EXPECT_NEAR(amounts(i, 1), x(i, 1), std::max(amounts(i, 1), x(i, 1)) * 1e-6);
 	}
+
+	// Test AutoDiff against FiniteDiff
+    test_PKModelOneCpt(pMatrix, time, amt, rate, ii, evid, cmt, addl, ss,
+                       1e-8, 1e-4);
 }
 
 TEST(Torsten, PKModelOneCpt_MultipleDoses_timePara) {
@@ -297,4 +305,8 @@ TEST(Torsten, PKModelOneCpt_MultipleDoses_timePara) {
 			   1.678828e-04, 0.7342228;
 			   
 	expect_matrix_eq(amounts, x);
-} */
+
+	// Test AutoDiff against FiniteDiff
+    test_PKModelOneCpt(pMatrix, time, amt, rate, ii, evid, cmt, addl, ss,
+                       1e-8, 1e-4);
+}

--- a/test/unit/math/torsten/prim/PKModelOneCpt_test.cpp
+++ b/test/unit/math/torsten/prim/PKModelOneCpt_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/torsten/torsten.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/prim/mat/fun/expect_matrix_eq.hpp>
+#include <test/unit/math/torsten/rev/util_torsten.hpp>
 
 using std::vector;
 using Eigen::Matrix;
@@ -15,11 +16,11 @@ TEST(Torsten, PKModelOneCpt_MultipleDoses) {
 	pMatrix[0][2] = 1.2; // ka
 	pMatrix[0][3] = 1; // F1
 	pMatrix[0][4] = 1; // F2
-	pMatrix[0][5] = 0; // tlag1
+	pMatrix[0][5] = 0; // tlag1 // SHOULD BE 0
 	pMatrix[0][6] = 0; // tlag2
 	
 	vector<double> time(10);
-	time[0] = 0.0;
+	time[0] = 0; // SHOULD BE 0
 	for(int i = 1; i < 9; i++) time[i] = time[i - 1] + 0.25;
 	time[9] = 4.0;
 
@@ -57,7 +58,11 @@ TEST(Torsten, PKModelOneCpt_MultipleDoses) {
 			   90.71795, 768.09246,
 			   8.229747, 667.87079;
 			   
-	expect_matrix_eq(amounts, x);
+	// expect_matrix_eq(amounts, x);
+
+	// Test AutoDiff against FiniteDiff
+    test_PKModelOneCpt(pMatrix, time, amt, rate, ii, evid, cmt, addl, ss,
+                       1e-8, 1e-4);
 }
 
 TEST(Torsten, PKModelOneCpt_MultipleDoses_overload) {
@@ -122,7 +127,7 @@ TEST(Torsten, PKModelOneCpt_SS) {
 	pMatrix[0][2] = 1.2; // ka
 	pMatrix[0][3] = 1; // F1
 	pMatrix[0][4] = 1; // F2
-	pMatrix[0][5] = 0; // tlag1
+	pMatrix[0][5] = 0; // tlag1 // SHOULD BE 0
 	pMatrix[0][6] = 0; // tlag2
 	
 	vector<double> time(10);
@@ -165,10 +170,14 @@ TEST(Torsten, PKModelOneCpt_SS) {
 	           2.220724e-3, 435.9617,
 	           9.875702, 1034.7998;
 
-	for(int i = 0; i < amounts.rows(); i++) {
+/*	for(int i = 0; i < amounts.rows(); i++) {
 		EXPECT_NEAR(amounts(i, 0), x(i, 0), std::max(amounts(i, 0), x(i, 0)) * 1e-6);
 		EXPECT_NEAR(amounts(i, 1), x(i, 1), std::max(amounts(i, 1), x(i, 1)) * 1e-6);
-	}
+	} */
+
+    // Test auto-diff
+    // test_PKModelOneCpt(pMatrix, time, amt, rate, ii, evid, cmt, addl, ss,
+    //                   1e-8, 1e-4);
 }
 
 TEST(Torsten, PKModelOneCpt_SS_rate) {

--- a/test/unit/math/torsten/prim/PKModelOneCpt_test.cpp
+++ b/test/unit/math/torsten/prim/PKModelOneCpt_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/torsten/torsten.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/prim/mat/fun/expect_matrix_eq.hpp>
-#include <test/unit/math/torsten/rev/util_torsten.hpp>
+#include <test/unit/math/torsten/prim/util_PKModelOneCpt.hpp>
 
 using std::vector;
 using Eigen::Matrix;
@@ -16,7 +16,7 @@ TEST(Torsten, PKModelOneCpt_MultipleDoses) {
 	pMatrix[0][2] = 1.2; // ka
 	pMatrix[0][3] = 1; // F1
 	pMatrix[0][4] = 1; // F2
-	pMatrix[0][5] = 0; // tlag1 // SHOULD BE 0
+	pMatrix[0][5] = 0; // tlag1
 	pMatrix[0][6] = 0; // tlag2
 	
 	vector<double> time(10);
@@ -57,14 +57,14 @@ TEST(Torsten, PKModelOneCpt_MultipleDoses) {
 			   122.4564, 760.25988,
 			   90.71795, 768.09246,
 			   8.229747, 667.87079;
-			   
-	// expect_matrix_eq(amounts, x);
+
+	expect_matrix_eq(amounts, x);
 
 	// Test AutoDiff against FiniteDiff
     test_PKModelOneCpt(pMatrix, time, amt, rate, ii, evid, cmt, addl, ss,
                        1e-8, 1e-4);
 }
-
+/*
 TEST(Torsten, PKModelOneCpt_MultipleDoses_overload) {
 
 	vector<double> pMatrix(7);
@@ -127,37 +127,37 @@ TEST(Torsten, PKModelOneCpt_SS) {
 	pMatrix[0][2] = 1.2; // ka
 	pMatrix[0][3] = 1; // F1
 	pMatrix[0][4] = 1; // F2
-	pMatrix[0][5] = 0; // tlag1 // SHOULD BE 0
+	pMatrix[0][5] = 0; // tlag1
 	pMatrix[0][6] = 0; // tlag2
-	
+
 	vector<double> time(10);
 	time[0] = 0.0;
 	time[1] = 0.0;
 	for(int i = 2; i < 10; i++) time[i] = time[i - 1] + 5;
-	
+
 	vector<double> amt(10, 0);
 	amt[0] = 1200;
-	
+
 	vector<double> rate(10, 0);
-	
+
 	vector<int> cmt(10, 2);
 	cmt[0] = 1;
-	
+
 	vector<int> evid(10, 0);
 	evid[0] = 1;
 
 	vector<double> ii(10, 0);
 	ii[0] = 12;
-	
+
 	vector<int> addl(10, 0);
 	addl[0] = 10;
-	
+
 	vector<int> ss(10, 0);
 	ss[0] = 1;
 
 	Matrix<double, Dynamic, Dynamic> x;
 	x = PKModelOneCpt(pMatrix, time, amt, rate, ii, evid, cmt, addl, ss);
-	
+
 	Matrix<double, Dynamic, Dynamic> amounts(10, 2);
 	amounts << 1200.0, 384.7363,
 	           1200.0, 384.7363,
@@ -170,10 +170,10 @@ TEST(Torsten, PKModelOneCpt_SS) {
 	           2.220724e-3, 435.9617,
 	           9.875702, 1034.7998;
 
-/*	for(int i = 0; i < amounts.rows(); i++) {
+    for(int i = 0; i < amounts.rows(); i++) {
 		EXPECT_NEAR(amounts(i, 0), x(i, 0), std::max(amounts(i, 0), x(i, 0)) * 1e-6);
 		EXPECT_NEAR(amounts(i, 1), x(i, 1), std::max(amounts(i, 1), x(i, 1)) * 1e-6);
-	} */
+	}
 
     // Test auto-diff
     // test_PKModelOneCpt(pMatrix, time, amt, rate, ii, evid, cmt, addl, ss,
@@ -181,7 +181,7 @@ TEST(Torsten, PKModelOneCpt_SS) {
 }
 
 TEST(Torsten, PKModelOneCpt_SS_rate) {
-	
+
 	vector<vector<double> > pMatrix(1);
 	pMatrix[0].resize(7);
 	pMatrix[0][0] = 10; // CL
@@ -297,4 +297,4 @@ TEST(Torsten, PKModelOneCpt_MultipleDoses_timePara) {
 			   1.678828e-04, 0.7342228;
 			   
 	expect_matrix_eq(amounts, x);
-}
+} */

--- a/test/unit/math/torsten/prim/PKModelOneCpt_test.cpp
+++ b/test/unit/math/torsten/prim/PKModelOneCpt_test.cpp
@@ -20,7 +20,7 @@ TEST(Torsten, PKModelOneCpt_MultipleDoses) {
 	pMatrix[0][6] = 0; // tlag2
 
 	vector<double> time(10);
-	time[0] = 0; // SHOULD BE 0
+	time[0] = 0;
 	for(int i = 1; i < 9; i++) time[i] = time[i - 1] + 0.25;
 	time[9] = 4.0;
 

--- a/test/unit/math/torsten/prim/PKModelTwoCpt_test.cpp
+++ b/test/unit/math/torsten/prim/PKModelTwoCpt_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/torsten/torsten.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/prim/mat/fun/expect_matrix_eq.hpp>
+#include <test/unit/math/torsten/prim/util_PKModelTwoCpt.hpp>
 
 using std::vector;
 using Eigen::Matrix;
@@ -62,6 +63,11 @@ TEST(Torsten, PKModelTwoCpt_MultipleDoses) {
 			   8.229747, 200.8720, 441.38985;
 			   
 	expect_matrix_eq(amounts, x);
+
+	// Test AutoDiff against FiniteDiff
+    test_PKModelTwoCpt(pMatrix, time, amt, rate, ii, evid, cmt, addl, ss,
+                       1e-8, 1e-4);
+
 }
 
 
@@ -120,6 +126,10 @@ TEST(Torsten, PKModelTwoCpt_MultipleDoses_overload) {
 			   8.229747, 200.8720, 441.38985;
 			   
 	expect_matrix_eq(amounts, x);
+
+	// Test AutoDiff against FiniteDiff
+    test_PKModelTwoCpt(pMatrix, time, amt, rate, ii, evid, cmt, addl, ss,
+                       1e-8, 1e-4);
 }
 
 
@@ -183,6 +193,10 @@ TEST(Torsten, PKModelTwoCpt_SS) {
 		EXPECT_NEAR(amounts(i, 0), x(i, 0), std::max(amounts(i, 0), x(i, 0)) * 1e-6);
 		EXPECT_NEAR(amounts(i, 1), x(i, 1), std::max(amounts(i, 1), x(i, 1)) * 1e-6);
 	}
+
+	// Test AutoDiff against FiniteDiff
+    test_PKModelTwoCpt(pMatrix, time, amt, rate, ii, evid, cmt, addl, ss,
+                       1e-8, 2e-4);
 }
 
 TEST(Torsten, PKModelTwoCpt_SS_rate) {
@@ -246,6 +260,10 @@ TEST(Torsten, PKModelTwoCpt_SS_rate) {
 		EXPECT_NEAR(amounts(i, 0), x(i, 0), std::max(amounts(i, 0), x(i, 0)) * 1e-6);
 		EXPECT_NEAR(amounts(i, 1), x(i, 1), std::max(amounts(i, 1), x(i, 1)) * 1e-6);
 	}
+
+	// Test AutoDiff against FiniteDiff
+    test_PKModelTwoCpt(pMatrix, time, amt, rate, ii, evid, cmt, addl, ss,
+                       1e-8, 2e-4);
 }
 
 TEST(Torsten, PKModelTwoCpt_MultipleDoses_timePara) {
@@ -310,4 +328,8 @@ TEST(Torsten, PKModelTwoCpt_MultipleDoses_timePara) {
 			   1.678828e-04,   6.690631, 164.0364;
 			   
 	expect_matrix_eq(amounts, x);
+
+	// Test AutoDiff against FiniteDiff
+    test_PKModelTwoCpt(pMatrix, time, amt, rate, ii, evid, cmt, addl, ss,
+                       1e-8, 1e-4);
 }

--- a/test/unit/math/torsten/prim/generalCptModel_test.cpp
+++ b/test/unit/math/torsten/prim/generalCptModel_test.cpp
@@ -4,6 +4,7 @@
 #include <test/unit/math/prim/mat/fun/expect_matrix_eq.hpp>
 #include <stan/math/torsten/GeneralCptModel_rk45.hpp>
 #include <stan/math/torsten/GeneralCptModel_bdf.hpp>
+// #include <test/unit/math/torsten/prim/util_generalOdeModel.hpp>
 
 template <typename T0, typename T1, typename T2, typename T3>
 inline
@@ -78,17 +79,20 @@ TEST(Torsten, genCpt_One_SingleDose) {
 	
   vector<int> ss(10, 0);
 
+  double rel_tol = 1e-8, abs_tol = 1e-8;
+  long int max_num_steps = 1e8;
+  int nCmt = 2;
   Matrix<double, Eigen::Dynamic, Eigen::Dynamic> x_rk45;
-  x_rk45 = generalCptModel_rk45(oneCptModelODE_functor(), 2,
+  x_rk45 = generalCptModel_rk45(oneCptModelODE_functor(), nCmt,
                                 pMatrix, time, amt, rate, ii, evid, cmt, addl, ss,
-                                1e-8, 1e-8, 1e8);
+                                rel_tol, abs_tol, max_num_steps);
 
   Matrix<double, Eigen::Dynamic, Eigen::Dynamic> x_bdf;
-  x_bdf = generalCptModel_bdf(oneCptModelODE_functor(), 2,
+  x_bdf = generalCptModel_bdf(oneCptModelODE_functor(), nCmt,
                               pMatrix, time, amt, rate, ii, evid, cmt, addl, ss,
-                              1e-8, 1e-8, 1e8);
-	
-  Matrix<double, Dynamic, Dynamic> amounts(10, 2);
+                              rel_tol, abs_tol, max_num_steps);
+
+  Matrix<double, Dynamic, Dynamic> amounts(10, nCmt);
   amounts << 1000.0, 0.0,
 	  	     740.8182, 254.97490,
 			 548.8116, 436.02020,
@@ -102,6 +106,13 @@ TEST(Torsten, genCpt_One_SingleDose) {
 
   expect_near_matrix_eq(amounts, x_rk45, rel_err);
   expect_near_matrix_eq(amounts, x_bdf, rel_err);
+
+  // Test AutoDiff against FiniteDiff
+/*  double diff = 1e-8, diff2 = 1e-4;
+  test_generalOdeModel(oneCptModelODE_functor(), nCmt, pMatrix,
+                       time, amt, rate, ii, evid, cmt, addl, ss,
+                       rel_tol, abs_tol, max_num_steps, diff, diff2, "rk45");
+                       */
 }
 
 TEST(Torsten, genCpt_One_SingleDose_overload) {

--- a/test/unit/math/torsten/prim/generalCptModel_test.cpp
+++ b/test/unit/math/torsten/prim/generalCptModel_test.cpp
@@ -4,7 +4,11 @@
 #include <test/unit/math/prim/mat/fun/expect_matrix_eq.hpp>
 #include <stan/math/torsten/GeneralCptModel_rk45.hpp>
 #include <stan/math/torsten/GeneralCptModel_bdf.hpp>
-// #include <test/unit/math/torsten/prim/util_generalOdeModel.hpp>
+#include <test/unit/math/torsten/prim/util_generalOdeModel.hpp>
+
+// Developer's note: for the autodiff test, the rk45 agrees 
+// more closely with finite diff than bdf by an order of
+// magnitude.
 
 template <typename T0, typename T1, typename T2, typename T3>
 inline
@@ -108,11 +112,14 @@ TEST(Torsten, genCpt_One_SingleDose) {
   expect_near_matrix_eq(amounts, x_bdf, rel_err);
 
   // Test AutoDiff against FiniteDiff
-/*  double diff = 1e-8, diff2 = 1e-4;
+  double diff = 1e-8, diff2 = 3e-3;
   test_generalOdeModel(oneCptModelODE_functor(), nCmt, pMatrix,
                        time, amt, rate, ii, evid, cmt, addl, ss,
                        rel_tol, abs_tol, max_num_steps, diff, diff2, "rk45");
-                       */
+  test_generalOdeModel(oneCptModelODE_functor(), nCmt, pMatrix,
+                       time, amt, rate, ii, evid, cmt, addl, ss,
+                       rel_tol, abs_tol, max_num_steps, diff, diff2, "bdf");
+  
 }
 
 TEST(Torsten, genCpt_One_SingleDose_overload) {
@@ -155,15 +162,18 @@ TEST(Torsten, genCpt_One_SingleDose_overload) {
 	
   vector<int> ss(10, 0);
 
+  double rel_tol = 1e-8, abs_tol = 1e-8;
+  long int max_num_steps = 1e8;
+  int nCmt = 2;
   Matrix<double, Eigen::Dynamic, Eigen::Dynamic> x_rk45;
-  x_rk45 = generalCptModel_rk45(oneCptModelODE_functor(), 2,
+  x_rk45 = generalCptModel_rk45(oneCptModelODE_functor(), nCmt,
                                 pMatrix, time, amt, rate, ii, evid, cmt, addl, ss,
-                                1e-8, 1e-8, 1e8);
+                                rel_tol, abs_tol, max_num_steps);
 
   Matrix<double, Eigen::Dynamic, Eigen::Dynamic> x_bdf;
-  x_bdf = generalCptModel_bdf(oneCptModelODE_functor(), 2,
+  x_bdf = generalCptModel_bdf(oneCptModelODE_functor(), nCmt,
                               pMatrix, time, amt, rate, ii, evid, cmt, addl, ss,
-                              1e-8, 1e-8, 1e8);
+                              rel_tol, abs_tol, max_num_steps);
 	
   Matrix<double, Dynamic, Dynamic> amounts(10, 2);
   amounts << 1000.0, 0.0,
@@ -179,6 +189,15 @@ TEST(Torsten, genCpt_One_SingleDose_overload) {
 
   expect_near_matrix_eq(amounts, x_rk45, rel_err);
   expect_near_matrix_eq(amounts, x_bdf, rel_err);
+
+  // Test AutoDiff against FiniteDiff
+  double diff = 1e-8, diff2 = 1e-2;
+  test_generalOdeModel(oneCptModelODE_functor(), nCmt, pMatrix,
+                       time, amt, rate, ii, evid, cmt, addl, ss,
+                       rel_tol, abs_tol, max_num_steps, diff, diff2, "rk45");
+  test_generalOdeModel(oneCptModelODE_functor(), nCmt, pMatrix,
+                       time, amt, rate, ii, evid, cmt, addl, ss,
+                       rel_tol, abs_tol, max_num_steps, diff, diff2, "bdf");
 }
 
 template <typename T0, typename T1, typename T2, typename T3>
@@ -193,12 +212,12 @@ oneCptModelODE_abstime(const T0& t,
 
   scalar CL0 = parms[0], V1 = parms[1], ka = parms[2], CLSS = parms[3],
     K = parms[4];
-  
+
   scalar CL = CL0 + (CLSS - CL0) * (1 - stan::math::exp(-K * t));  
   scalar k10 = CL / V1;
 
   std::vector<scalar> y(2, 0);
-  
+
   y[0] = -ka * x[0];
   y[1] = ka * x[0] - k10 * x[1];
 
@@ -218,14 +237,13 @@ struct oneCptModelODE_abstime_functor {
     }
 };
 
-
 TEST(Torsten, genCpt_One_abstime_SingleDose) {
   using std::vector;
   using Eigen::Matrix;
   using Eigen::Dynamic;
 
   double rel_err = 1e-6;
-  
+
   vector<vector<double> > pMatrix(1);
   pMatrix[0].resize(9);
   pMatrix[0][0] = 10; // CL0
@@ -262,15 +280,18 @@ TEST(Torsten, genCpt_One_abstime_SingleDose) {
 	
   vector<int> ss(10, 0);
 
+  int nCmt = 2;
+  double rel_tol = 1e-8, abs_tol = 1e-8;
+  long int max_num_steps = 1e8;
   Matrix<double, Eigen::Dynamic, Eigen::Dynamic> x_rk45;
   x_rk45 = generalCptModel_rk45(oneCptModelODE_abstime_functor(), 2,
                                 pMatrix, time, amt, rate, ii, evid, cmt, addl, ss,
-                                1e-8, 1e-8, 1e8);
+                                rel_tol, abs_tol, max_num_steps);
   
   Matrix<double, Eigen::Dynamic, Eigen::Dynamic> x_bdf;
-  x_bdf = generalCptModel_bdf(oneCptModelODE_abstime_functor(), 2,
+  x_bdf = generalCptModel_bdf(oneCptModelODE_abstime_functor(), nCmt,
                               pMatrix, time, amt, rate, ii, evid, cmt, addl, ss,
-                              1e-8, 1e-8, 1e8);
+                              rel_tol, abs_tol, max_num_steps);
 	
   Matrix<double, Dynamic, Dynamic> amounts(10, 2);
   amounts << 1000.0, 0.0,
@@ -286,9 +307,18 @@ TEST(Torsten, genCpt_One_abstime_SingleDose) {
 			  
   expect_near_matrix_eq(amounts, x_rk45, rel_err);
   expect_near_matrix_eq(amounts, x_bdf, rel_err);
+
+  // Test AutoDiff against FiniteDiff
+  double diff = 1e-8, diff2 = .25; // CHECK - diff2 seems pretty high!!
+  test_generalOdeModel(oneCptModelODE_abstime_functor(), nCmt, pMatrix,
+                       time, amt, rate, ii, evid, cmt, addl, ss,
+                       rel_tol, abs_tol, max_num_steps, diff, diff2, "rk45");
+  test_generalOdeModel(oneCptModelODE_abstime_functor(), nCmt, pMatrix,
+                       time, amt, rate, ii, evid, cmt, addl, ss,
+                       rel_tol, abs_tol, max_num_steps, diff, diff2, "bdf");
 }
 
-TEST(Torsten, genCpOne_MultipleDoses_timePara) {
+TEST(Torsten, genCptOne_MultipleDoses_timePara) {
     using std::vector;
     using Eigen::Matrix;
     using Eigen::Dynamic;
@@ -334,15 +364,18 @@ TEST(Torsten, genCpOne_MultipleDoses_timePara) {
 	
 	vector<int> ss(nEvent, 0);
 
+    int nCmt = 2;
+    double rel_tol = 1e-8, abs_tol = 1e-8;
+    long int max_num_steps = 1e8;
     Matrix<double, Eigen::Dynamic, Eigen::Dynamic> x_rk45;
-    x_rk45 = generalCptModel_rk45(oneCptModelODE_functor(), 2,
+    x_rk45 = generalCptModel_rk45(oneCptModelODE_functor(), nCmt,
                                   pMatrix, time, amt, rate, ii, evid, cmt, addl, ss,
-                                  1e-8, 1e-8, 1e8);
+                                  rel_tol, abs_tol, max_num_steps);
   
     Matrix<double, Eigen::Dynamic, Eigen::Dynamic> x_bdf;
-    x_bdf = generalCptModel_bdf(oneCptModelODE_functor(), 2,
+    x_bdf = generalCptModel_bdf(oneCptModelODE_functor(), nCmt,
                                 pMatrix, time, amt, rate, ii, evid, cmt, addl, ss,
-                                1e-8, 1e-8, 1e8);
+                                rel_tol, abs_tol, max_num_steps);
 
 	Matrix<double, Dynamic, Dynamic> amounts(nEvent, 2);
 	amounts << 1000.0, 0.0,
@@ -359,4 +392,13 @@ TEST(Torsten, genCpOne_MultipleDoses_timePara) {
 			   
     expect_near_matrix_eq(amounts, x_rk45, rel_err_rk45);
     expect_near_matrix_eq(amounts, x_bdf, rel_err_bdf);
+
+  // Test AutoDiff against FiniteDiff
+  double diff = 1e-8, diff2 = 1e-2;
+  test_generalOdeModel(oneCptModelODE_functor(), nCmt, pMatrix,
+                       time, amt, rate, ii, evid, cmt, addl, ss,
+                       rel_tol, abs_tol, max_num_steps, diff, diff2, "rk45");
+  test_generalOdeModel(oneCptModelODE_functor(), nCmt, pMatrix,
+                       time, amt, rate, ii, evid, cmt, addl, ss,
+                       rel_tol, abs_tol, max_num_steps, diff, diff2, "bdf");
 }

--- a/test/unit/math/torsten/prim/linCptModel_test.cpp
+++ b/test/unit/math/torsten/prim/linCptModel_test.cpp
@@ -66,7 +66,7 @@ TEST(Torsten, LinCpt_OneSS) {
 		EXPECT_NEAR(amounts(i, 1), x(i, 1), std::max(amounts(i, 1), x(i, 1)) * 1e-6);
 	}
 
-	double diff = 1e-8, diff2 = 1e-2;
+	double diff = 1e-8, diff2 = 1e-4;
 	test_linOdeModel(system_array, pMatrix, time, amt, rate, ii, evid, cmt, addl,
 		                 ss, diff, diff2);
 }
@@ -147,9 +147,9 @@ TEST(Torsten, LinCpt_OneSS_overloads) {
 		  std::max(amounts(i, 1), x3(i, 1)) * 1e-6);
 	}
 
-//	double diff = 1e-8, diff2 = 1e-2;
-//	test_linOdeModel(system_array, pMatrix, time, amt, rate, ii, evid, cmt, addl,
-//	                 ss, diff, diff2);
+	double diff = 1e-8, diff2 = 1e-4;
+	test_linOdeModel(system_array, pMatrix, time, amt, rate, ii, evid, cmt, addl,
+		             ss, diff, diff2);
 }
 
 TEST(Torsten, linCptModel_OneSS_rate) {
@@ -212,9 +212,9 @@ TEST(Torsten, linCptModel_OneSS_rate) {
 		EXPECT_NEAR(amounts(i, 1), x(i, 1), std::max(amounts(i, 1), x(i, 1)) * 1e-6);
 	}
 
-//	double diff = 1e-8, diff2 = 1e-2;
-//	test_linOdeModel(system_array, pMatrix, time, amt, rate, ii, evid, cmt, addl,
-//	                 ss, diff, diff2);
+	double diff = 1e-8, diff2 = 1e-4;
+	test_linOdeModel(system_array, pMatrix, time, amt, rate, ii, evid, cmt, addl,
+		             ss, diff, diff2);
 
 }
 
@@ -280,8 +280,8 @@ TEST(Torsten, linOne_MultipleDoses_timePara) {
 
 	expect_matrix_eq(amounts, x);
 
-//	double diff = 1e-8, diff2 = 1e-2;
-//	test_linOdeModel(system_array, pMatrix, time, amt, rate, ii, evid, cmt, addl,
-//	                 ss, diff, diff2);
+	double diff = 1e-8, diff2 = 1e-4;
+	test_linOdeModel(system_array, pMatrix, time, amt, rate, ii, evid, cmt, addl,
+		             ss, diff, diff2);
 }
 

--- a/test/unit/math/torsten/prim/linCptModel_test.cpp
+++ b/test/unit/math/torsten/prim/linCptModel_test.cpp
@@ -1,6 +1,7 @@
 #include <stan/math/rev/mat.hpp>
 #include <gtest/gtest.h>
 #include <test/unit/math/prim/mat/fun/expect_matrix_eq.hpp>
+#include <test/unit/math/torsten/prim/util_linOdeModel.hpp>
 
 using std::vector;
 using Eigen::Matrix;
@@ -64,6 +65,10 @@ TEST(Torsten, LinCpt_OneSS) {
 		EXPECT_NEAR(amounts(i, 0), x(i, 0), std::max(amounts(i, 0), x(i, 0)) * 1e-6);
 		EXPECT_NEAR(amounts(i, 1), x(i, 1), std::max(amounts(i, 1), x(i, 1)) * 1e-6);
 	}
+
+	double diff = 1e-8, diff2 = 1e-2;
+	test_linOdeModel(system_array, pMatrix, time, amt, rate, ii, evid, cmt, addl,
+		                 ss, diff, diff2);
 }
 
 TEST(Torsten, LinCpt_OneSS_overloads) {
@@ -141,6 +146,10 @@ TEST(Torsten, LinCpt_OneSS_overloads) {
 		EXPECT_NEAR(amounts(i, 1), x3(i, 1),
 		  std::max(amounts(i, 1), x3(i, 1)) * 1e-6);
 	}
+
+//	double diff = 1e-8, diff2 = 1e-2;
+//	test_linOdeModel(system_array, pMatrix, time, amt, rate, ii, evid, cmt, addl,
+//	                 ss, diff, diff2);
 }
 
 TEST(Torsten, linCptModel_OneSS_rate) {
@@ -202,6 +211,11 @@ TEST(Torsten, linCptModel_OneSS_rate) {
 		EXPECT_NEAR(amounts(i, 0), x(i, 0), std::max(amounts(i, 0), x(i, 0)) * 1e-6);
 		EXPECT_NEAR(amounts(i, 1), x(i, 1), std::max(amounts(i, 1), x(i, 1)) * 1e-6);
 	}
+
+//	double diff = 1e-8, diff2 = 1e-2;
+//	test_linOdeModel(system_array, pMatrix, time, amt, rate, ii, evid, cmt, addl,
+//	                 ss, diff, diff2);
+
 }
 
 TEST(Torsten, linOne_MultipleDoses_timePara) {
@@ -265,5 +279,9 @@ TEST(Torsten, linOne_MultipleDoses_timePara) {
 			   1.678828e-04, 0.7342228;
 
 	expect_matrix_eq(amounts, x);
+
+//	double diff = 1e-8, diff2 = 1e-2;
+//	test_linOdeModel(system_array, pMatrix, time, amt, rate, ii, evid, cmt, addl,
+//	                 ss, diff, diff2);
 }
 

--- a/test/unit/math/torsten/prim/util_PKModelTwoCpt.hpp
+++ b/test/unit/math/torsten/prim/util_PKModelTwoCpt.hpp
@@ -1,0 +1,181 @@
+#ifndef TEST_UNIT_MATH_TORSTEN_REV_UTIL_TORSTEN_HPP
+#define TEST_UNIT_MATH_TORSTEN_REV_UTIL_TORSTEN_HPP
+
+#include <stan/math/rev/mat.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/math/rev/arr/util.hpp>
+#include <test/unit/util.hpp>
+
+/*
+ * Calculates finite difference for PKModelOneCpt with varying parameters. 
+ */
+Eigen::Matrix <double, Eigen::Dynamic, Eigen::Dynamic>
+finite_diff_params(const std::vector<std::vector<double> >& pMatrix,
+                   const std::vector<double>& time,
+                   const std::vector<double>& amt,
+                   const std::vector<double>& rate,
+                   const std::vector<double>& ii,
+                   const std::vector<int>& evid,
+                   const std::vector<int>& cmt,
+                   const std::vector<int>& addl,
+                   const std::vector<int>& ss,
+                   const size_t& param_row,
+                   const size_t& param_col,
+                   const double& diff) {
+  using std::vector;
+  using Eigen::Matrix;
+  using Eigen::Dynamic;
+
+  vector<double> parameters(pMatrix[0].size());
+  vector<vector<double> > pMatrix_ub(pMatrix.size(), parameters);
+  vector<vector<double> > pMatrix_lb(pMatrix.size(), parameters);
+  for (size_t i = 0; i < pMatrix.size(); i++)
+    for (size_t j = 0; j < pMatrix[0].size(); j++) {
+      if (i == param_row && j == param_col) {        
+        pMatrix_ub[i][j] = pMatrix[i][j] + diff;
+        pMatrix_lb[i][j] = pMatrix[i][j] - diff;
+      } else {
+        pMatrix_ub[i][j] = pMatrix[i][j];
+        pMatrix_lb[i][j] = pMatrix[i][j];
+      }
+    }
+
+  Matrix<double, Dynamic, Dynamic> pk_res_ub;
+  Matrix<double, Dynamic, Dynamic> pk_res_lb;
+  pk_res_ub = PKModelTwoCpt(pMatrix_ub, time, amt, rate, ii, evid, cmt,
+                            addl, ss);
+  pk_res_lb = PKModelTwoCpt(pMatrix_lb, time, amt, rate, ii, evid, cmt,
+                            addl, ss);
+
+  return (pk_res_ub - pk_res_lb) / (2 * diff);
+}
+
+/*
+ * Test PKModelTwoCpt with only pMatrix as vars and all other continuous
+ * arguments as double.
+ * Note: There is known issue when computing the derivative w.r.t the
+ * lag time of a dosing compartment. The issue is reported on GitHub,
+ * and the unit test overlooks it.
+ */
+void test_PKModelTwoCpt_finite_diff_v(
+    const std::vector<std::vector<double> >& pMatrix,
+    const std::vector<double>& time,
+    const std::vector<double>& amt,
+    const std::vector<double>& rate,
+    const std::vector<double>& ii,
+    const std::vector<int>& evid,
+    const std::vector<int>& cmt,
+    const std::vector<int>& addl,
+    const std::vector<int>& ss,
+    const double& diff,
+    const double& diff2) {
+  using std::vector;
+  using Eigen::Matrix;
+  using Eigen::Dynamic;
+  using stan::math::var;
+
+  size_t parmRows = pMatrix.size();
+  size_t parmCols = pMatrix[0].size();
+  size_t total_param = parmRows * parmCols;
+  vector<vector<Matrix<double, Dynamic, Dynamic> > > finite_diff_res(parmRows);
+  for(size_t i =  0; i < parmRows; i++)
+    finite_diff_res[i].resize(parmCols);
+
+  for(size_t i = 0; i < parmRows; i++) {
+    for(size_t j = 0; j < parmCols; j++) {
+      finite_diff_res[i][j] = finite_diff_params(pMatrix, time, amt, rate,
+                                      ii, evid, cmt, addl, ss, i, j, diff);
+    }
+  }
+
+  // Create pMatrix with vars
+  vector<var> parameters(total_param);
+  vector<vector<var> > pMatrix_v(parmRows);
+  for (size_t i = 0; i < parmRows; i++) pMatrix_v[i].resize(parmCols);
+  for (size_t i = 0; i < parmRows; i++) {
+    for (size_t j = 0; j < parmCols; j++) {
+      parameters[i * parmCols + j] = pMatrix[i][j];
+      pMatrix_v[i][j] = parameters[i * parmCols + j];
+    }
+  }
+
+  Matrix<var, Dynamic, Dynamic> ode_res;
+  ode_res = PKModelTwoCpt(pMatrix_v, time, amt, rate, ii, evid, cmt, addl, ss);
+
+  int nCmt = 3;
+  size_t nEvent = time.size();
+
+  // Identify dosing compartment
+  vector<size_t> tlagIndexes(nCmt);
+  for (int i = 0; i < nCmt; i++)
+    tlagIndexes[i] = parmCols - nCmt + i;
+  vector<bool> isDosingCmt(nCmt);
+  for (size_t i = 0; i < nEvent; i++)
+    if (evid[i] == 1 || evid[i] == 4) isDosingCmt[cmt[i] - 1] = true;
+
+  vector<double> grads_eff(nEvent * nCmt);
+  for (size_t i = 0; i < nEvent; i++)
+    for (int j = 0; j < nCmt; j++) {
+      grads_eff.clear();
+      ode_res(i, j).grad(parameters, grads_eff);
+
+      for (size_t k = 0; k < parmRows; k++)
+        for (size_t l = 0; l < parmCols; l++) {
+
+         bool discontinuous = false;
+         for (int m = 0; m < nCmt; m++)
+           if (l == tlagIndexes[m] && isDosingCmt[m]) discontinuous = true;
+
+          if (discontinuous == false) {
+            EXPECT_NEAR(grads_eff[k * parmCols + l],
+              finite_diff_res[k][l](i, j), diff2)
+              << "Gradient of PKModelTwoCpt failed with known"
+              << " time, amt, rate, ii, evid, cmt, addl, ss "
+              << " and unknown parameters at event " << i
+              << ", in compartment " << j
+              << ", and parameter index (" << k << ", " << l << ")";
+          }
+        }
+      stan::math::set_zero_all_adjoints();
+    }
+}
+
+void test_PKModelTwoCpt(const std::vector<std::vector<double> >& pMatrix,
+                        const std::vector<double>& time,
+                        const std::vector<double>& amt,
+                        const std::vector<double>& rate,
+                        const std::vector<double>& ii,
+                        const std::vector<int>& evid,
+                        const std::vector<int>& cmt,
+                        const std::vector<int>& addl,
+                        const std::vector<int>& ss,
+                        const double& diff,
+                        const double& diff2) {
+  test_PKModelTwoCpt_finite_diff_v(pMatrix, time, amt, rate, ii, evid,
+                                   cmt, addl, ss, diff, diff2);
+}
+
+void test_PKModelTwoCpt(const std::vector<double>& pMatrix_v,
+                        const std::vector<double>& time,
+                        const std::vector<double>& amt,
+                        const std::vector<double>& rate,
+                        const std::vector<double>& ii,
+                        const std::vector<int>& evid,
+                        const std::vector<int>& cmt,
+                        const std::vector<int>& addl,
+                        const std::vector<int>& ss,
+                        const double& diff,
+                        const double& diff2) {
+  std::vector<std::vector<double> > pMatrix(1, pMatrix_v);
+  test_PKModelTwoCpt(pMatrix, time, amt, rate, ii, evid, cmt, addl, ss,
+                     diff, diff2);
+}
+
+
+// More tests
+// test_ode_error_conditions
+// test_ode_error_conditions_nan
+// test_ode_error_conditions_inf
+// test_ode_error_conditions_vd
+
+#endif

--- a/test/unit/math/torsten/prim/util_PKModelTwoCpt.hpp
+++ b/test/unit/math/torsten/prim/util_PKModelTwoCpt.hpp
@@ -7,7 +7,7 @@
 #include <test/unit/util.hpp>
 
 /*
- * Calculates finite difference for PKModelOneCpt with varying parameters. 
+ * Calculates finite difference for PKModelTwoCpt with varying parameters. 
  */
 Eigen::Matrix <double, Eigen::Dynamic, Eigen::Dynamic>
 finite_diff_params(const std::vector<std::vector<double> >& pMatrix,

--- a/test/unit/math/torsten/prim/util_generalOdeModel.hpp
+++ b/test/unit/math/torsten/prim/util_generalOdeModel.hpp
@@ -1,0 +1,220 @@
+#ifndef TEST_UNIT_MATH_TORSTEN_REV_UTIL_TORSTEN_HPP
+#define TEST_UNIT_MATH_TORSTEN_REV_UTIL_TORSTEN_HPP
+
+#include <stan/math/rev/mat.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/math/rev/arr/util.hpp>
+#include <test/unit/util.hpp>
+
+/*
+ * Calculates finite difference for PKModelOneCpt with varying parameters. 
+ */
+template <typename F>
+Eigen::Matrix <double, Eigen::Dynamic, Eigen::Dynamic>
+finite_diff_params(const F& f,
+                   const int nCmt,
+                   const std::vector<std::vector<double> >& pMatrix,
+                   const std::vector<double>& time,
+                   const std::vector<double>& amt,
+                   const std::vector<double>& rate,
+                   const std::vector<double>& ii,
+                   const std::vector<int>& evid,
+                   const std::vector<int>& cmt,
+                   const std::vector<int>& addl,
+                   const std::vector<int>& ss,
+                   double rel_tol,
+                   double abs_tol,
+                   long int max_num_steps,
+                   const size_t& param_row,
+                   const size_t& param_col,
+                   const double& diff,
+                   const std::string odeInt) {
+  using std::vector;
+  using Eigen::Matrix;
+  using Eigen::Dynamic;
+
+  vector<double> parameters(pMatrix[0].size());
+  vector<vector<double> > pMatrix_ub(pMatrix.size(), parameters);
+  vector<vector<double> > pMatrix_lb(pMatrix.size(), parameters);
+  for (size_t i = 0; i < pMatrix.size(); i++)
+    for (size_t j = 0; j < pMatrix[0].size(); j++) {
+      if (i == param_row && j == param_col) {        
+        pMatrix_ub[i][j] = pMatrix[i][j] + diff;
+        pMatrix_lb[i][j] = pMatrix[i][j] - diff;
+      } else {
+        pMatrix_ub[i][j] = pMatrix[i][j];
+        pMatrix_lb[i][j] = pMatrix[i][j];
+      }
+    }
+
+  Matrix<double, Dynamic, Dynamic> pk_res_ub;
+  Matrix<double, Dynamic, Dynamic> pk_res_lb;
+/*  if (odeInt == "rk45") {
+    pk_res_ub = generalCptModel_rk45(f, nCmt, pMatrix_ub, time, amt, rate, ii,
+                                     evid, cmt,addl, ss);
+    pk_res_lb = generalCptModel_rk45(f, nCmt, pMatrix_lb, time, amt, rate, ii,
+                                     evid, cmt, addl, ss);
+  }
+  if (odeInt == "bdf") {
+    pk_res_ub = generalCptModel_rk45(f, nCmt, pMatrix_ub, time, amt, rate, ii,
+                                     evid, cmt,addl, ss);
+    pk_res_lb = generalCptModel_rk45(f, nCmt, pMatrix_lb, time, amt, rate, ii,
+                                     evid, cmt, addl, ss);  
+  }
+*/
+  return (pk_res_ub - pk_res_lb) / (2 * diff);
+}
+
+/*
+ * Test PKModelOneCpt with only pMatrix as vars and all other continuous
+ * arguments as double.
+ * Note: There is known issue when computing the derivative w.r.t the
+ * lag time of a dosing compartment. The issue is reported on GitHub,
+ * and the unit test overlooks it.
+ */
+template <typename F>
+void test_generalOdeModel_finite_diff_v(
+    const F& f,
+    const int nCmt,
+    const std::vector<std::vector<double> >& pMatrix,
+    const std::vector<double>& time,
+    const std::vector<double>& amt,
+    const std::vector<double>& rate,
+    const std::vector<double>& ii,
+    const std::vector<int>& evid,
+    const std::vector<int>& cmt,
+    const std::vector<int>& addl,
+    const std::vector<int>& ss,
+    double rel_tol,
+    double abs_tol,
+    long int max_num_steps,
+    const double& diff,
+    const double& diff2,
+    const std::string odeInt) {
+  using std::vector;
+  using Eigen::Matrix;
+  using Eigen::Dynamic;
+  using stan::math::var;
+
+  size_t parmRows = pMatrix.size();
+  size_t parmCols = pMatrix[0].size();
+  size_t total_param = parmRows * parmCols;
+  vector<vector<Matrix<double, Dynamic, Dynamic> > > finite_diff_res(parmRows);
+  for(size_t i =  0; i < parmRows; i++)
+    finite_diff_res[i].resize(parmCols);
+
+  for(size_t i = 0; i < parmRows; i++) {
+    for(size_t j = 0; j < parmCols; j++) {
+      finite_diff_res[i][j] = finite_diff_params(f, nCmt, pMatrix, time, amt,
+                                                 rate, ii, evid, cmt, addl,
+                                                 ss, rel_tol, abs_tol, 
+                                                 max_num_steps, i, j, diff);
+    }
+  }
+/*
+  // Create pMatrix with vars
+  vector<var> parameters(total_param);
+  vector<vector<var> > pMatrix_v(parmRows);
+  for (size_t i = 0; i < parmRows; i++) pMatrix_v[i].resize(parmCols);
+  for (size_t i = 0; i < parmRows; i++) {
+    for (size_t j = 0; j < parmCols; j++) {
+      parameters[i * parmCols + j] = pMatrix[i][j];
+      pMatrix_v[i][j] = parameters[i * parmCols + j];
+    }
+  }
+
+  Matrix<var, Dynamic, Dynamic> ode_res;
+  ode_res = PKModelOneCpt(pMatrix_v, time, amt, rate, ii, evid, cmt, addl, ss);
+
+  size_t nEvent = time.size();
+
+  // Identify dosing compartment
+  vector<size_t> tlagIndexes(nCmt);
+  for (int i = 0; i < nCmt; i++)
+    tlagIndexes[i] = parmCols - nCmt + i;
+  vector<bool> isDosingCmt(nCmt);
+  for (size_t i = 0; i < nEvent; i++)
+    if (evid[i] == 1 || evid[i] == 4) isDosingCmt[cmt[i] - 1] = true;
+
+  vector<double> grads_eff(nEvent * nCmt);
+  for (size_t i = 0; i < nEvent; i++)
+    for (int j = 0; j < nCmt; j++) {
+      grads_eff.clear();
+      ode_res(i, j).grad(parameters, grads_eff);
+
+      for (size_t k = 0; k < parmRows; k++)
+        for (size_t l = 0; l < parmCols; l++) {
+
+         bool discontinuous = false;
+         for (int m = 0; m < nCmt; m++)
+           if (l == tlagIndexes[m] && isDosingCmt[m]) discontinuous = true;
+
+          if (discontinuous == false) {
+            EXPECT_NEAR(grads_eff[k * parmCols + l],
+              finite_diff_res[k][l](i, j), diff2)
+              << "Gradient of PKModelOneCpt failed with known"
+              << " time, amt, rate, ii, evid, cmt, addl, ss "
+              << " and unknown parameters at event " << i
+              << ", in compartment " << j
+              << ", and parameter index (" << k << ", " << l << ")";
+          }
+        }
+      stan::math::set_zero_all_adjoints();
+    } */
+}
+
+template <typename F>
+void test_generalOdeModel(const F& f,
+                          const int nCmt,
+                          const std::vector<std::vector<double> >& pMatrix,
+                          const std::vector<double>& time,
+                          const std::vector<double>& amt,
+                          const std::vector<double>& rate,
+                          const std::vector<double>& ii,
+                          const std::vector<int>& evid,
+                          const std::vector<int>& cmt,
+                          const std::vector<int>& addl,
+                          const std::vector<int>& ss,
+                          const double rel_tol,
+                          const double abs_tol,
+                          const long int max_num_steps,
+                          const double& diff,
+                          const double& diff2,
+                          std::string odeInt) {
+  test_generalOdeModel(f, nCmt, pMatrix, time, amt, rate, ii, evid, cmt,
+                       addl, ss, rel_tol, abs_tol, max_num_steps, diff, diff2,
+                       odeInt);
+}
+
+template <typename F>
+void test_generalOdeModel(const F& f,
+                          const int nCmt,
+                          const std::vector<double>& pMatrix_v,
+                          const std::vector<double>& time,
+                          const std::vector<double>& amt,
+                          const std::vector<double>& rate,
+                          const std::vector<double>& ii,
+                          const std::vector<int>& evid,
+                          const std::vector<int>& cmt,
+                          const std::vector<int>& addl,
+                          const std::vector<int>& ss,
+                          double rel_tol,
+                          double abs_tol,
+                          long int max_num_steps,
+                          const double& diff,
+                          const double& diff2,
+                          std::string odeInt) {
+  std::vector<std::vector<double> > pMatrix(1, pMatrix_v);
+  test_generalOdeModel(f, nCmt, pMatrix, time, amt, rate, ii, evid, cmt,
+                       addl, ss, rel_tol, abs_tol, max_num_steps, diff, diff2,
+                       odeInt);
+}
+
+
+// More tests
+// test_ode_error_conditions
+// test_ode_error_conditions_nan
+// test_ode_error_conditions_inf
+// test_ode_error_conditions_vd
+
+#endif

--- a/test/unit/math/torsten/prim/util_linOdeModel.hpp
+++ b/test/unit/math/torsten/prim/util_linOdeModel.hpp
@@ -1,0 +1,283 @@
+#ifndef TEST_UNIT_MATH_TORSTEN_REV_UTIL_TORSTEN_HPP
+#define TEST_UNIT_MATH_TORSTEN_REV_UTIL_TORSTEN_HPP
+
+#include <stan/math/rev/mat.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/math/rev/arr/util.hpp>
+#include <test/unit/util.hpp>
+
+/*
+ * Calculates finite difference for generalOdeModel with varying parameters.
+ * Parameters can be stored in pMatrix and/or system. Need to specify
+ * the row and column of the parameter in these object. For system, also
+ * need to specify the event number (recall system is a vector of matrix).  
+ */
+Eigen::Matrix <double, Eigen::Dynamic, Eigen::Dynamic>
+finite_diff_params(const std::vector< Eigen::Matrix<double, Eigen::Dynamic,
+		     Eigen::Dynamic> >& system,
+                   const std::vector<std::vector<double> >& pMatrix,
+                   const std::vector<double>& time,
+                   const std::vector<double>& amt,
+                   const std::vector<double>& rate,
+                   const std::vector<double>& ii,
+                   const std::vector<int>& evid,
+                   const std::vector<int>& cmt,
+                   const std::vector<int>& addl,
+                   const std::vector<int>& ss,
+                   const size_t& param_row,
+                   const size_t& param_col,
+		           const size_t& param_z,
+                   const double& diff,
+                   const std::string parmType) { 
+  using std::vector;
+  using Eigen::Matrix;
+  using Eigen::Dynamic;
+
+  vector<double> parameters(pMatrix[0].size());
+  vector<vector<double> > pMatrix_ub(pMatrix.size(), parameters);
+  vector<vector<double> > pMatrix_lb(pMatrix.size(), parameters);
+  for (size_t i = 0; i < pMatrix.size(); i++)
+    for (size_t j = 0; j < pMatrix[0].size(); j++) {
+      if ((i == param_row && j == param_col) && parmType == "pMatrix") {        
+        pMatrix_ub[i][j] = pMatrix[i][j] + diff;
+        pMatrix_lb[i][j] = pMatrix[i][j] - diff;
+      } else {
+        pMatrix_ub[i][j] = pMatrix[i][j];
+        pMatrix_lb[i][j] = pMatrix[i][j];
+      }
+    }
+
+  Matrix<double, Dynamic, Dynamic> system_1(system[0].rows(), system[0].cols());
+  vector<Matrix<double, Dynamic, Dynamic> > system_ub(system.size(), system_1);
+  vector<Matrix<double, Dynamic, Dynamic> > system_lb(system.size(), system_1);
+  for (size_t z = 0; z < system.size(); z++)
+    for (int i = 0; i < system[0].rows(); i++)
+      for (int j = 0; j < system[0].cols(); j++) {      
+        if (((size_t) i == param_row
+             && (size_t) j == param_col)
+             && (z == param_z
+             && parmType == "system")) {
+	      system_ub[z](i, j) = system[z](i, j) + diff;
+	      system_lb[z](i, j) = system[z](i, j) - diff;
+        } else {
+	      system_ub[z](i, j) = system[z](i, j);
+	      system_lb[z](i, j) = system[z](i, j);
+        }
+      }
+	
+  Matrix<double, Dynamic, Dynamic> pk_res_ub;
+  Matrix<double, Dynamic, Dynamic> pk_res_lb;
+  pk_res_ub = linCptModel(system_ub, pMatrix_ub, time, amt, rate, ii, evid, cmt, addl, ss);
+  pk_res_lb = linCptModel(system_lb, pMatrix_lb, time, amt, rate, ii, evid, cmt, addl, ss);
+
+  return (pk_res_ub - pk_res_lb) / (2 * diff);
+}
+
+/*
+ * Test linearOdeModel with only pMatrix as vars and all other 
+ * continuous arguments as double.
+ * Note: There is known issue when computing the derivative w.r.t the
+ * lag time of a dosing compartment. The issue is reported on GitHub,
+ * and the unit test overlooks it.
+ */
+void test_linearOdeModel_finite_diff_dv(
+    const std::vector<Eigen::Matrix<double, Eigen::Dynamic,
+      Eigen::Dynamic> >& system,
+    const std::vector<std::vector<double> >& pMatrix,
+    const std::vector<double>& time,
+    const std::vector<double>& amt,
+    const std::vector<double>& rate,
+    const std::vector<double>& ii,
+    const std::vector<int>& evid,
+    const std::vector<int>& cmt,
+    const std::vector<int>& addl,
+    const std::vector<int>& ss,
+    const double& diff,
+    const double& diff2) {
+  using std::vector;
+  using Eigen::Matrix;
+  using Eigen::Dynamic;
+  using stan::math::var;
+
+  size_t parmRows = pMatrix.size();
+  size_t parmCols = pMatrix[0].size();
+  size_t total_param = parmRows * parmCols;
+  vector<vector<Matrix<double, Dynamic, Dynamic> > > finite_diff_res(parmRows);
+  for(size_t i =  0; i < parmRows; i++)
+    finite_diff_res[i].resize(parmCols);
+
+  for(size_t i = 0; i < parmRows; i++) {
+    for(size_t j = 0; j < parmCols; j++) {
+      finite_diff_res[i][j] = finite_diff_params(system, pMatrix, time, amt,
+                                                 rate, ii, evid, cmt, addl,
+                                                 ss, i, j, 0,  diff,
+                                                 "pMatrix");
+    }
+  }
+
+  // Create pMatrix with vars
+  vector<var> parameters(total_param);
+  vector<vector<var> > pMatrix_v(parmRows);
+  for (size_t i = 0; i < parmRows; i++) {  // CHECK this loop doesn't cause an error
+    pMatrix_v[i].resize(parmCols);
+    for (size_t j = 0; j < parmCols; j++) {
+      parameters[i * parmCols + j] = pMatrix[i][j];
+      pMatrix_v[i][j] = parameters[i * parmCols + j];
+    }
+  }
+
+  Matrix<var, Dynamic, Dynamic> ode_res;
+  ode_res = linCptModel(system, pMatrix_v,
+                        time, amt, rate, ii, evid, cmt, addl, ss);
+
+  size_t nEvent = time.size();
+
+  // Identify dosing compartment
+  int nCmt = system[0].cols();
+  vector<size_t> tlagIndexes(nCmt);
+  for (int i = 0; i < nCmt; i++)
+    tlagIndexes[i] = parmCols - nCmt + i;
+  vector<bool> isDosingCmt(nCmt);
+  for (size_t i = 0; i < nEvent; i++)
+    if (evid[i] == 1 || evid[i] == 4) isDosingCmt[cmt[i] - 1] = true;
+
+  vector<double> grads_eff(nEvent * nCmt);
+  for (size_t i = 0; i < nEvent; i++)
+    for (int j = 0; j < nCmt; j++) {
+      grads_eff.clear();
+      ode_res(i, j).grad(parameters, grads_eff);
+
+      for (size_t k = 0; k < parmRows; k++)
+        for (size_t l = 0; l < parmCols; l++) {
+
+         bool discontinuous = false;
+         for (int m = 0; m < nCmt; m++)
+           if (l == tlagIndexes[m] && isDosingCmt[m]) discontinuous = true;
+
+          if (discontinuous == false) {
+            EXPECT_NEAR(grads_eff[k * parmCols + l],
+              finite_diff_res[k][l](i, j), diff2)
+              << "Gradient of generalOdeModel failed with known"
+              << " time, amt, rate, ii, evid, cmt, addl, ss "
+              << " and unknown parameters at event " << i
+              << ", in compartment " << j
+              << ", and parameter index (" << k << ", " << l << ")";
+          }
+        }
+      stan::math::set_zero_all_adjoints();
+    }  
+}
+
+/*
+ * Test linearOdeModel with only system as vars and all other
+ * continuous arguments as double.
+ */
+void test_linearOdeModel_finite_diff_vd(
+    const std::vector<Eigen::Matrix<double, Eigen::Dynamic,
+      Eigen::Dynamic> >& system,
+    const std::vector<std::vector<double> >& pMatrix,
+    const std::vector<double>& time,
+    const std::vector<double>& amt,
+    const std::vector<double>& rate,
+    const std::vector<double>& ii,
+    const std::vector<int>& evid,
+    const std::vector<int>& cmt,
+    const std::vector<int>& addl,
+    const std::vector<int>& ss,
+    const double diff,
+    const double diff2) {
+  using std::vector;
+  using Eigen::Matrix;
+  using Eigen::Dynamic;
+  using stan::math::var;
+
+  size_t nCmt = system[0].rows();
+  size_t nSystems = system.size();
+
+  // Size object to store finite diff results
+  vector<vector<vector<Matrix<double, Dynamic, Dynamic> > > >
+    finite_diff_res(nSystems);
+  for (size_t z = 0; z < nSystems; z++) {
+    finite_diff_res[z].resize(nCmt);
+    for (size_t i = 0; i < nCmt; i++)
+      finite_diff_res[z][i].resize(nCmt);
+  }
+
+  // Compute finite diff results
+  for (size_t z = 0; z < nSystems; z++)
+    for (size_t k = 0; k < nCmt; k++)
+      for (size_t l = 0; l < nCmt; l++)
+        finite_diff_res[z][k][l]
+          = finite_diff_params(system, pMatrix, time, amt, rate, ii, evid,
+                               cmt, addl, ss, k, l, z, diff, "system");
+
+  std::vector<double> grads_eff;
+
+  // Create system with vars instead of doubles
+  size_t totalParam = nCmt * nCmt * nSystems;
+  vector<var> parameters(totalParam);
+  vector<Matrix<var, Dynamic, Dynamic> > system_v(nSystems);
+  for (size_t z = 0; z < nSystems; z++) {
+    system_v[z].resize(nCmt, nCmt);
+    for (size_t i = 0; i < nCmt; i++)  // CHECK: no bracket ??
+      for (size_t j = 0; j < nCmt; j++) {
+        parameters[z * nCmt * nCmt + i * nCmt + j] = system[z](i, j);
+        system_v[z](i, j) = parameters[z * nCmt * nCmt + i * nCmt + j];
+      }
+  }
+
+  // Compute return of linOdeModel
+  Matrix<var, Dynamic, Dynamic> ode_res
+    = linCptModel(system_v, pMatrix, time, amt, rate, ii, evid, cmt, addl,
+                  ss);
+
+  // Test auto-diff
+  size_t nEvents = time.size();
+  for (size_t i = 0; i < nEvents; i++)
+    for (size_t j = 0; j < nCmt; j++) {
+      grads_eff.clear();
+      ode_res(i, j).grad(parameters, grads_eff);
+
+      for (size_t z = 0; z < nSystems; z++)
+        for (size_t k = 0; k < nCmt; k++)
+          for (size_t l = 0; l < nCmt; l++)
+            EXPECT_NEAR(grads_eff[z * nCmt * nCmt + k * nCmt + l],
+              finite_diff_res[z][k][l](i, j), diff2)
+              << "Gradient of generalOdeModel failed with known"
+              << " time, amt, rate, ii, evid, cmt, addl, ss"
+              << " and unknown parameters at event " << i
+              << ", in compartment " << j
+              << ", and parameter index (" << z << ", " << k << ", "
+              << l << ")";
+
+      stan::math::set_zero_all_adjoints();
+  }
+}    
+
+void test_linOdeModel(const std::vector<Eigen::Matrix<double, Eigen::Dynamic,
+		        Eigen::Dynamic> > system,
+                      const std::vector<std::vector<double> >& pMatrix,
+                      const std::vector<double>& time,
+                      const std::vector<double>& amt,
+                      const std::vector<double>& rate,
+                      const std::vector<double>& ii,
+                      const std::vector<int>& evid,
+                      const std::vector<int>& cmt,
+                      const std::vector<int>& addl,
+                      const std::vector<int>& ss,
+                      const double& diff,
+                      const double& diff2) {
+  test_linearOdeModel_finite_diff_dv(system, pMatrix, time, amt, rate,
+                                   ii, evid, cmt, addl, ss, diff, diff2);
+
+  test_linearOdeModel_finite_diff_vd(system, pMatrix, time, amt, rate,
+                                     ii, evid, cmt, addl, ss, diff, diff2);
+}
+
+// More tests
+// test_ode_error_conditions
+// test_ode_error_conditions_nan
+// test_ode_error_conditions_inf
+// test_ode_error_conditions_vd
+
+#endif

--- a/test/unit/math/torsten/prim/util_linOdeModel.hpp
+++ b/test/unit/math/torsten/prim/util_linOdeModel.hpp
@@ -255,7 +255,7 @@ void test_linearOdeModel_finite_diff_vd(
 }    
 
 void test_linOdeModel(const std::vector<Eigen::Matrix<double, Eigen::Dynamic,
-		        Eigen::Dynamic> > system,
+		                Eigen::Dynamic> > system,
                       const std::vector<std::vector<double> >& pMatrix,
                       const std::vector<double>& time,
                       const std::vector<double>& amt,
@@ -271,6 +271,88 @@ void test_linOdeModel(const std::vector<Eigen::Matrix<double, Eigen::Dynamic,
                                    ii, evid, cmt, addl, ss, diff, diff2);
 
   test_linearOdeModel_finite_diff_vd(system, pMatrix, time, amt, rate,
+                                     ii, evid, cmt, addl, ss, diff, diff2);
+}
+
+/*
+ * Overload with System as a matrix.
+ */
+void test_linOdeModel(const Eigen::Matrix<double, Eigen::Dynamic,
+		                Eigen::Dynamic> system,
+                      const std::vector<std::vector<double> >& pMatrix,
+                      const std::vector<double>& time,
+                      const std::vector<double>& amt,
+                      const std::vector<double>& rate,
+                      const std::vector<double>& ii,
+                      const std::vector<int>& evid,
+                      const std::vector<int>& cmt,
+                      const std::vector<int>& addl,
+                      const std::vector<int>& ss,
+                      const double& diff,
+                      const double& diff2) {
+  std::vector<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> >
+    system_vec(1, system);
+
+  test_linearOdeModel_finite_diff_dv(system_vec, pMatrix, time, amt, rate,
+                                   ii, evid, cmt, addl, ss, diff, diff2);
+
+  test_linearOdeModel_finite_diff_vd(system_vec, pMatrix, time, amt, rate,
+                                     ii, evid, cmt, addl, ss, diff, diff2);
+}
+
+/*
+ * Overload with pMatrix as a 1d array.
+ */
+void test_linOdeModel(const std::vector<Eigen::Matrix<double, Eigen::Dynamic,
+		                Eigen::Dynamic> > system,
+                      const std::vector<double>& pMatrix,
+                      const std::vector<double>& time,
+                      const std::vector<double>& amt,
+                      const std::vector<double>& rate,
+                      const std::vector<double>& ii,
+                      const std::vector<int>& evid,
+                      const std::vector<int>& cmt,
+                      const std::vector<int>& addl,
+                      const std::vector<int>& ss,
+                      const double& diff,
+                      const double& diff2) {
+  using std::vector;
+  vector<vector<double> > pMatrix_vec(1, pMatrix);
+
+  test_linearOdeModel_finite_diff_dv(system, pMatrix_vec, time, amt, rate,
+                                   ii, evid, cmt, addl, ss, diff, diff2);
+
+  test_linearOdeModel_finite_diff_vd(system, pMatrix_vec, time, amt, rate,
+                                     ii, evid, cmt, addl, ss, diff, diff2);
+}
+
+/*
+ * Overload with System as a matrix and pMatrix 
+ * as a 1d array.
+ */
+void test_linOdeModel(const Eigen::Matrix<double, Eigen::Dynamic,
+		                Eigen::Dynamic> system,
+                      const std::vector<double>& pMatrix,
+                      const std::vector<double>& time,
+                      const std::vector<double>& amt,
+                      const std::vector<double>& rate,
+                      const std::vector<double>& ii,
+                      const std::vector<int>& evid,
+                      const std::vector<int>& cmt,
+                      const std::vector<int>& addl,
+                      const std::vector<int>& ss,
+                      const double& diff,
+                      const double& diff2) {
+  using std::vector;
+  vector<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> >
+    system_vec(1, system);
+
+  vector<vector<double> > pMatrix_vec(1, pMatrix);
+
+  test_linearOdeModel_finite_diff_dv(system_vec, pMatrix_vec, time, amt, rate,
+                                   ii, evid, cmt, addl, ss, diff, diff2);
+
+  test_linearOdeModel_finite_diff_vd(system_vec, pMatrix_vec, time, amt, rate,
                                      ii, evid, cmt, addl, ss, diff, diff2);
 }
 

--- a/test/unit/math/torsten/rev/generalCptModel_test.cpp
+++ b/test/unit/math/torsten/rev/generalCptModel_test.cpp
@@ -97,8 +97,8 @@ TEST(Torsten, genCpt_One_SingleDose) {
 			 90.71795, 768.09246,
 			 8.229747, 667.87079;
 
-  for (size_t i = 0; i < amounts.rows(); i++)
-    for (size_t j = 0; j < amounts.cols(); j++) {
+  for (int i = 0; i < amounts.rows(); i++)
+    for (int j = 0; j < amounts.cols(); j++) {
       EXPECT_NEAR(amounts(i, j), x_rk45(i, j).val(),
         std::max(amounts(i, j), x_rk45(i, j).val()) * rel_err);
       EXPECT_NEAR(amounts(i, j), x_bdf(i, j).val(),
@@ -168,8 +168,8 @@ TEST(Torsten, genCpt_One_SingleDose_overload) {
 			 90.71795, 768.09246,
 			 8.229747, 667.87079;
 
-  for (size_t i = 0; i < amounts.rows(); i++)
-    for (size_t j = 0; j < amounts.cols(); j++) {
+  for (int i = 0; i < amounts.rows(); i++)
+    for (int j = 0; j < amounts.cols(); j++) {
       EXPECT_NEAR(amounts(i, j), x_rk45(i, j).val(),
         std::max(amounts(i, j), x_rk45(i, j).val()) * rel_err);
       EXPECT_NEAR(amounts(i, j), x_bdf(i, j).val(),
@@ -279,8 +279,8 @@ TEST(Torsten, genCpt_One_abstime_SingleDose) {
 			 90.71795, 840.0581,
 			 8.229747, 869.0283;
 			  
-  for (size_t i = 0; i < amounts.rows(); i++)
-    for (size_t j = 0; j < amounts.cols(); j++) {
+  for (int i = 0; i < amounts.rows(); i++)
+    for (int j = 0; j < amounts.cols(); j++) {
       EXPECT_NEAR(amounts(i, j), x_rk45(i, j).val(),
         std::max(amounts(i, j), x_rk45(i, j).val()) * rel_err);
       EXPECT_NEAR(amounts(i, j), x_bdf(i, j).val(),
@@ -356,8 +356,8 @@ TEST(Torsten, genCpOne_MultipleDoses_timePara) {
 			   3.372017e-03, 3.4974152,
 			   1.678828e-04, 0.7342228;
 			   
-  for (size_t i = 0; i < amounts.rows(); i++)
-    for (size_t j = 0; j < amounts.cols(); j++) {
+  for (int i = 0; i < amounts.rows(); i++)
+    for (int j = 0; j < amounts.cols(); j++) {
       EXPECT_NEAR(amounts(i, j), x_rk45(i, j).val(),
         std::max(amounts(i, j), x_rk45(i, j).val()) * rel_err_rk45);
       EXPECT_NEAR(amounts(i, j), x_bdf(i, j).val(),

--- a/test/unit/math/torsten/rev/util_torsten.hpp
+++ b/test/unit/math/torsten/rev/util_torsten.hpp
@@ -1,0 +1,169 @@
+#ifndef TEST_UNIT_MATH_TORSTEN_REV_UTIL_TORSTEN_HPP
+#define TEST_UNIT_MATH_TORSTEN_REV_UTIL_TORSTEN_HPP
+
+#include <stan/math/rev/mat.hpp>
+#include <gtest/gtest.h>
+#include <test/unit/math/rev/arr/util.hpp>
+#include <test/unit/util.hpp>
+
+/*
+ * Calculates finite diffs for PKModelOneCpt with varying parameters. 
+ */
+Eigen::Matrix <double, Eigen::Dynamic, Eigen::Dynamic>
+finite_diff_params(const std::vector<std::vector<double> >& pMatrix,
+                   const std::vector<double>& time,
+                   const std::vector<double>& amt,
+                   const std::vector<double>& rate,
+                   const std::vector<double>& ii,
+                   const std::vector<int>& evid,
+                   const std::vector<int>& cmt,
+                   const std::vector<int>& addl,
+                   const std::vector<int>& ss,
+                   const size_t& param_row,
+                   const size_t& param_col,
+                   const double& diff) {
+  using std::vector;
+  using Eigen::Matrix;
+  using Eigen::Dynamic;
+
+  vector<double> parameters(pMatrix[0].size());
+  vector<vector<double> > pMatrix_ub(pMatrix.size(), parameters);
+  vector<vector<double> > pMatrix_lb(pMatrix.size(), parameters);
+  for (size_t i = 0; i < pMatrix.size(); i++)
+    for (size_t j = 0; j < pMatrix[0].size(); j++) {
+      if (i == param_row && j == param_col) {        
+        pMatrix_ub[i][j] = pMatrix[i][j] + diff;
+        pMatrix_lb[i][j] = pMatrix[i][j] - diff;
+      } else {
+        pMatrix_ub[i][j] = pMatrix[i][j];
+        pMatrix_lb[i][j] = pMatrix[i][j];
+      }
+    }
+
+  Matrix<double, Dynamic, Dynamic> pk_res_ub;
+  Matrix<double, Dynamic, Dynamic> pk_res_lb;
+  pk_res_ub = PKModelOneCpt(pMatrix_ub, time, amt, rate, ii, evid, cmt,
+                            addl, ss);
+  pk_res_lb = PKModelOneCpt(pMatrix_lb, time, amt, rate, ii, evid, cmt,
+                            addl, ss);
+
+  return (pk_res_ub - pk_res_lb) / (2 * diff);
+}
+
+
+/*
+ * Test PKModelOneCpt with only pMatrix as vars and all other continuous
+ * arguments as double.
+ * Note: In dosing compartment n at times t = t_dosing + t_lag_n we
+ * expect a discontinuity in the derivatives. This is an ISSUE.
+ * For now, the function does NOT test the derivative around this
+ * expected discontinuity.
+ */
+void test_PKModelOneCpt_finite_diff_v(
+    const std::vector<std::vector<double> >& pMatrix,
+    const std::vector<double>& time,
+    const std::vector<double>& amt,
+    const std::vector<double>& rate,
+    const std::vector<double>& ii,
+    const std::vector<int>& evid,
+    const std::vector<int>& cmt,
+    const std::vector<int>& addl,
+    const std::vector<int>& ss,
+    const double& diff,
+    const double& diff2) {
+  using std::vector;
+  using Eigen::Matrix;
+  using Eigen::Dynamic;
+  using stan::math::var;
+
+  size_t parmRows = pMatrix.size();
+  size_t parmCols = pMatrix[0].size();
+  size_t total_param = parmRows * parmCols;
+  vector<vector<Matrix<double, Dynamic, Dynamic> > > finite_diff_res(parmRows);
+  for(size_t i =  0; i < parmRows; i++)
+    finite_diff_res[i].resize(parmCols);
+
+  for(size_t i = 0; i < parmRows; i++) {
+    for(size_t j = 0; j < parmCols; j++) {
+      finite_diff_res[i][j] = finite_diff_params(pMatrix, time, amt, rate,
+                                      ii, evid, cmt, addl, ss, i, j, diff);
+    }
+  }
+
+  vector<var> parameters(total_param);
+  vector<vector<var> > pMatrix_v(parmRows);
+  for (size_t i = 0; i < parmRows; i++) pMatrix_v[i].resize(parmCols);
+  for (size_t i = 0; i < parmRows; i++) {
+    for (size_t j = 0; j < parmCols; j++) {
+      parameters[i * parmCols + j] = pMatrix[i][j];
+      pMatrix_v[i][j] = parameters[i * parmCols + j];
+    }
+  }
+
+  Matrix<var, Dynamic, Dynamic> ode_res;
+  ode_res = PKModelOneCpt(pMatrix_v, time, amt, rate, ii, evid, cmt, addl, ss);
+
+  int nCmt = 2;
+  size_t nEvent = time.size();
+
+  // Identify points with parameters w.r.t which
+  // PKModelOneCpt is discontinuous.  
+  vector<int> discParmIndex;
+  for (int i = 0; i < nCmt; i++)
+    for (size_t j = 0; j < nEvent; j++)
+      if ((evid[j] == 1 || evid[j] == 4) &&  // dosing event
+        (rate[j] == 0))  // bolus dosing
+        discParmIndex.push_back(parmCols - (i + 1));
+
+  vector<double> grads_eff(nEvent * nCmt);
+  for (size_t i = 0; i < nEvent; i++)
+    for (int j = 0; j < nCmt; j++) {
+      grads_eff.clear();
+      ode_res(i, j).grad(parameters, grads_eff);
+
+      for (size_t k = 0; k < parmRows; k++)
+        for (size_t l = 0; l < parmCols; l++) {
+
+          bool discontinuous = false;
+          for (size_t m = 0; m < discParmIndex.size(); m++)
+            if ((int) l == discParmIndex[m]) discontinuous = true;
+
+          if (discontinuous == false) {
+            EXPECT_NEAR(grads_eff[k * parmCols + l],
+              finite_diff_res[k][l](i, j), diff2)
+              << "Gradient of PKModelOneCpt failed with known"
+              << " time, amt, rate, ii, evid, cmt, addl, ss "
+              << " and unknown parameters at event " << i
+              << ", in compartment " << j
+              << ", and parameter index (" << k << ", " << l << ")";
+          }
+        }
+      stan::math::set_zero_all_adjoints();
+    }
+
+}
+
+void test_PKModelOneCpt(const std::vector<std::vector<double> >& pMatrix,
+                        const std::vector<double>& time,
+                        const std::vector<double>& amt,
+                        const std::vector<double>& rate,
+                        const std::vector<double>& ii,
+                        const std::vector<int>& evid,
+                        const std::vector<int>& cmt,
+                        const std::vector<int>& addl,
+                        const std::vector<int>& ss,
+                        const double& diff,
+                        const double& diff2) {
+  test_PKModelOneCpt_finite_diff_v(pMatrix, time, amt, rate, ii, evid,
+                                   cmt, addl, ss, diff, diff2);
+}
+
+
+// More tests
+// test_ode_error_conditions
+// test_ode_error_conditions_nan
+// test_ode_error_conditions_inf
+// test_ode_error_conditions_vd
+// test_ode : runs all the ODEs
+
+#endif


### PR DESCRIPTION
#### Submisison Checklist

- [X] Run unit tests: `./runTests.py test/unit/torsten`
- [X] Run cpplint: `make cpplint`
- [X] Declare copyright holder and open-source license: see below

#### Summary:
Resolves parts of issue #16. The progress is significant enough to merge this branch `torsten-develop`.
 
Tests automatic differentiation (auto-diff) for parameters stored in `pMatrix`, the parameter matrix and `system`, the rate constant matrix. Creates `util` files with functions that computed differentiation and compare the result to auto-diff. 

#### Intended Effect:
Unit tests test computation of the gradient, with respect to `pMatrix` and `system`.

#### How to Verify:
Finite-diff and auto-diff are in close agreement (1e-4, with some notable and expected exceptions in functions that use numerical integrators). A third independent check would be desirable, though I'm not sure how to get one.

#### Side Effects:
None.

#### Documentation:
None. I hope the code is readable. I closely followed the example of `integrate_ode_bdf`. The finite differentiation functions are straightforward. Most of the difficulty comes from the heavy bookkeeping. Each function returns a matrix and takes in a lot of arguments (i.e. a lot of dependent variables to derive w.r.t a lot of independent variables). 

#### Further Notes: 
I'll need to extend the tests to handle parameters, which are not stored in `pMatrix` and `system`. And `tlags`, once issue #17 is resolved.


#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Metrum Research Group LLC

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
