### PR TITLE
Issue 26 ode tuning

### DIFF
--- a/stan/math/prim/arr/functor/integrate_ode_rk45.hpp
+++ b/stan/math/prim/arr/functor/integrate_ode_rk45.hpp
@@ -74,6 +74,11 @@ namespace stan {
                        double relative_tolerance = 1e-6,
                        double absolute_tolerance = 1e-6,
                        int max_num_steps = 1E6) {
+      // print statements for debugging
+      std::cout << "rel_tol: " << relative_tolerance << std::endl;
+      std::cout << "abs_tol: " << absolute_tolerance << std::endl;
+      std::cout << "maxStep: " << max_num_steps << std::endl;
+
       using boost::numeric::odeint::integrate_times;
       using boost::numeric::odeint::make_dense_output;
       using boost::numeric::odeint::runge_kutta_dopri5;

--- a/stan/math/prim/arr/functor/integrate_ode_rk45.hpp
+++ b/stan/math/prim/arr/functor/integrate_ode_rk45.hpp
@@ -14,6 +14,8 @@
 #include <ostream>
 #include <vector>
 
+#include <gtest/gtest.h>
+
 namespace stan {
   namespace math {
 
@@ -74,10 +76,10 @@ namespace stan {
                        double relative_tolerance = 1e-6,
                        double absolute_tolerance = 1e-6,
                        int max_num_steps = 1E6) {
-      // print statements for debugging
-      std::cout << "rel_tol: " << relative_tolerance << std::endl;
-      std::cout << "abs_tol: " << absolute_tolerance << std::endl;
-      std::cout << "maxStep: " << max_num_steps << std::endl;
+      // unit test for debugging
+      EXPECT_EQ(1e-8, relative_tolerance);
+      EXPECT_EQ(1e-8, absolute_tolerance);
+      EXPECT_EQ(1e+8, max_num_steps);
 
       using boost::numeric::odeint::integrate_times;
       using boost::numeric::odeint::make_dense_output;

--- a/stan/math/prim/arr/functor/integrate_ode_rk45.hpp
+++ b/stan/math/prim/arr/functor/integrate_ode_rk45.hpp
@@ -14,8 +14,6 @@
 #include <ostream>
 #include <vector>
 
-#include <gtest/gtest.h>
-
 namespace stan {
   namespace math {
 
@@ -76,11 +74,6 @@ namespace stan {
                        double relative_tolerance = 1e-6,
                        double absolute_tolerance = 1e-6,
                        int max_num_steps = 1E6) {
-      // unit test for debugging
-      EXPECT_EQ(1e-8, relative_tolerance);
-      EXPECT_EQ(1e-8, absolute_tolerance);
-      EXPECT_EQ(1e+8, max_num_steps);
-
       using boost::numeric::odeint::integrate_times;
       using boost::numeric::odeint::make_dense_output;
       using boost::numeric::odeint::runge_kutta_dopri5;

--- a/stan/math/torsten/generalOdeModel_bdf.hpp
+++ b/stan/math/torsten/generalOdeModel_bdf.hpp
@@ -44,7 +44,11 @@
  * @param[in] max_num_steps maximal number of steps to take within 
  *            the Boost ode solver 
  * @return a matrix with predicted amount in each compartment 
- *         at each event. 
+ *         at each event.
+ *
+ * FIX ME: currently have a dummy msgs argument. Makes it easier
+ * to expose to stan grammar files, because I can follow more closely
+ * what was done for the ODE integrator. Not ideal.
  */
 template <typename T0, typename T1, typename T2, typename T3, typename T4,
           typename T5, typename T6, typename F>
@@ -64,9 +68,10 @@ generalOdeModel_bdf(const F& f,
                     const std::vector<std::vector<T4> >& pMatrix,
                     const std::vector<std::vector<T5> >& biovar,
                     const std::vector<std::vector<T6> >& tlag,
-                    double rel_tol = 1e-10,
-                    double abs_tol = 1e-10,
-                    long int max_num_steps = 1e8) {  // NOLINT(runtime/int)
+                    std::ostream* msgs = 0,
+                    double rel_tol = 1e-6,
+                    double abs_tol = 1e-6,
+                    long int max_num_steps = 1e6) {  // NOLINT(runtime/int)
   using std::vector;
   using Eigen::Dynamic;
   using Eigen::Matrix;
@@ -124,9 +129,10 @@ generalOdeModel_bdf(const F& f,
                      const std::vector<T4>& pMatrix,
                      const std::vector<std::vector<T5> >& biovar,
                      const std::vector<std::vector<T6> >& tlag,
-                     double rel_tol = 1e-10,
-                     double abs_tol = 1e-10,
-                     long int max_num_steps = 1e8) {  // NOLINT(runtime/int)
+                     std::ostream* msgs = 0,
+                     double rel_tol = 1e-6,
+                     double abs_tol = 1e-6,
+                     long int max_num_steps = 1e6) {  // NOLINT(runtime/int)
   std::vector<std::vector<T4> > vec_pMatrix(1, pMatrix);
 
   return generalOdeModel_bdf(f, nCmt,
@@ -156,9 +162,10 @@ generalOdeModel_bdf(const F& f,
                      const std::vector<T4>& pMatrix,
                      const std::vector<T5>& biovar,
                      const std::vector<std::vector<T6> >& tlag,
-                     double rel_tol = 1e-10,
-                     double abs_tol = 1e-10,
-                     long int max_num_steps = 1e8) {  // NOLINT(runtime/int)
+                     std::ostream* msgs = 0,
+                     double rel_tol = 1e-6,
+                     double abs_tol = 1e-6,
+                     long int max_num_steps = 1e6) {  // NOLINT(runtime/int)
   std::vector<std::vector<T4> > vec_pMatrix(1, pMatrix);
   std::vector<std::vector<T5> > vec_biovar(1, biovar);
 
@@ -189,9 +196,10 @@ generalOdeModel_bdf(const F& f,
                      const std::vector<T4>& pMatrix,
                      const std::vector<T5>& biovar,
                      const std::vector<T6>& tlag,
-                     double rel_tol = 1e-10,
-                     double abs_tol = 1e-10,
-                     long int max_num_steps = 1e8) {  // NOLINT(runtime/int)
+                     std::ostream* msgs = 0,
+                     double rel_tol = 1e-6,
+                     double abs_tol = 1e-6,
+                     long int max_num_steps = 1e6) {  // NOLINT(runtime/int)
   std::vector<std::vector<T4> > vec_pMatrix(1, pMatrix);
   std::vector<std::vector<T5> > vec_biovar(1, biovar);
   std::vector<std::vector<T6> > vec_tlag(1, tlag);
@@ -223,9 +231,10 @@ generalOdeModel_bdf(const F& f,
                      const std::vector<T4>& pMatrix,
                      const std::vector<std::vector<T5> >& biovar,
                      const std::vector<T6>& tlag,
-                     double rel_tol = 1e-10,
-                     double abs_tol = 1e-10,
-                     long int max_num_steps = 1e8) {  // NOLINT(runtime/int)
+                     std::ostream* msgs = 0,
+                     double rel_tol = 1e-6,
+                     double abs_tol = 1e-6,
+                     long int max_num_steps = 1e6) {  // NOLINT(runtime/int)
   std::vector<std::vector<T4> > vec_pMatrix(1, pMatrix);
   std::vector<std::vector<T6> > vec_tlag(1, tlag);
 
@@ -256,9 +265,10 @@ generalOdeModel_bdf(const F& f,
                      const std::vector<std::vector<T4> >& pMatrix,
                      const std::vector<T5>& biovar,
                      const std::vector<std::vector<T6> >& tlag,
-                     double rel_tol = 1e-10,
-                     double abs_tol = 1e-10,
-                     long int max_num_steps = 1e8) {  // NOLINT(runtime/int)
+                     std::ostream* msgs = 0,
+                     double rel_tol = 1e-6,
+                     double abs_tol = 1e-6,
+                     long int max_num_steps = 1e6) {  // NOLINT(runtime/int)
   std::vector<std::vector<T5> > vec_biovar(1, biovar);
 
   return generalOdeModel_bdf(f, nCmt,
@@ -288,9 +298,10 @@ generalOdeModel_bdf(const F& f,
                      const std::vector<std::vector<T4> >& pMatrix,
                      const std::vector<T5>& biovar,
                      const std::vector<T6>& tlag,
-                     double rel_tol = 1e-10,
-                     double abs_tol = 1e-10,
-                     long int max_num_steps = 1e8) {  // NOLINT(runtime/int)
+                     std::ostream* msgs = 0,
+                     double rel_tol = 1e-6,
+                     double abs_tol = 1e-6,
+                     long int max_num_steps = 1e6) {  // NOLINT(runtime/int)
   std::vector<std::vector<T5> > vec_biovar(1, biovar);
   std::vector<std::vector<T6> > vec_tlag(1, tlag);
 
@@ -321,9 +332,10 @@ generalOdeModel_bdf(const F& f,
                      const std::vector<std::vector<T4> >& pMatrix,
                      const std::vector<std::vector<T5> >& biovar,
                      const std::vector<T6>& tlag,
-                     double rel_tol = 1e-10,
-                     double abs_tol = 1e-10,
-                     long int max_num_steps = 1e8) {  // NOLINT(runtime/int)
+                     std::ostream* msgs = 0,
+                     double rel_tol = 1e-6,
+                     double abs_tol = 1e-6,
+                     long int max_num_steps = 1e6) {  // NOLINT(runtime/int)
   std::vector<std::vector<T6> > vec_tlag(1, tlag);
 
   return generalOdeModel_bdf(f, nCmt,

--- a/stan/math/torsten/generalOdeModel_bdf.hpp
+++ b/stan/math/torsten/generalOdeModel_bdf.hpp
@@ -137,7 +137,8 @@ generalOdeModel_bdf(const F& f,
 
   return generalOdeModel_bdf(f, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss,
-                              vec_pMatrix, biovar, tlag);
+                              vec_pMatrix, biovar, tlag,
+                              msgs, rel_tol, abs_tol, max_num_steps);
 }
 
 /**
@@ -171,7 +172,8 @@ generalOdeModel_bdf(const F& f,
 
   return generalOdeModel_bdf(f, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss,
-                              vec_pMatrix, vec_biovar, tlag);
+                              vec_pMatrix, vec_biovar, tlag,
+                              msgs, rel_tol, abs_tol, max_num_steps);
 }
 
 /**
@@ -206,7 +208,8 @@ generalOdeModel_bdf(const F& f,
 
   return generalOdeModel_bdf(f, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss,
-                              vec_pMatrix, vec_biovar, vec_tlag);
+                              vec_pMatrix, vec_biovar, vec_tlag,
+                              msgs, rel_tol, abs_tol, max_num_steps);
 }
 
 /**
@@ -240,7 +243,8 @@ generalOdeModel_bdf(const F& f,
 
   return generalOdeModel_bdf(f, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss,
-                              vec_pMatrix, biovar, vec_tlag);
+                              vec_pMatrix, biovar, vec_tlag,
+                              msgs, rel_tol, abs_tol, max_num_steps);
 }
 
 /**
@@ -273,7 +277,8 @@ generalOdeModel_bdf(const F& f,
 
   return generalOdeModel_bdf(f, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss,
-                              pMatrix, vec_biovar, tlag);
+                              pMatrix, vec_biovar, tlag,
+                              msgs, rel_tol, abs_tol, max_num_steps);
 }
 
 /**
@@ -307,7 +312,8 @@ generalOdeModel_bdf(const F& f,
 
   return generalOdeModel_bdf(f, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss,
-                              pMatrix, vec_biovar, vec_tlag);
+                              pMatrix, vec_biovar, vec_tlag,
+                              msgs, rel_tol, abs_tol, max_num_steps);
 }
 
 /**
@@ -340,7 +346,8 @@ generalOdeModel_bdf(const F& f,
 
   return generalOdeModel_bdf(f, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss,
-                              pMatrix, biovar, vec_tlag);
+                              pMatrix, biovar, vec_tlag,
+                              msgs, rel_tol, abs_tol, max_num_steps);
 }
 
 #endif

--- a/stan/math/torsten/generalOdeModel_rk45.hpp
+++ b/stan/math/torsten/generalOdeModel_rk45.hpp
@@ -45,6 +45,10 @@
  *            the Boost ode solver 
  * @return a matrix with predicted amount in each compartment 
  *         at each event. 
+ *
+ * FIX ME: currently have a dummy msgs argument. Makes it easier
+ * to expose to stan grammar files, because I can follow more closely
+ * what was done for the ODE integrator. Not ideal.
  */
 template <typename T0, typename T1, typename T2, typename T3, typename T4,
   typename T5, typename T6, typename F>
@@ -64,9 +68,10 @@ generalOdeModel_rk45(const F& f,
                      const std::vector<std::vector<T4> >& pMatrix,
                      const std::vector<std::vector<T5> >& biovar,
                      const std::vector<std::vector<T6> >& tlag,
-                     double rel_tol = 1e-10,
-                     double abs_tol = 1e-10,
-                     long int max_num_steps = 1e8) {  // NOLINT(runtime/int)
+                     std::ostream* msgs = 0,
+                     double rel_tol = 1e-6,
+                     double abs_tol = 1e-6,
+                     long int max_num_steps = 1e6) {  // NOLINT(runtime/int)
   using std::vector;
   using Eigen::Dynamic;
   using Eigen::Matrix;
@@ -124,9 +129,10 @@ generalOdeModel_rk45(const F& f,
                      const std::vector<T4>& pMatrix,
                      const std::vector<std::vector<T5> >& biovar,
                      const std::vector<std::vector<T6> >& tlag,
-                     double rel_tol = 1e-10,
-                     double abs_tol = 1e-10,
-                     long int max_num_steps = 1e8) {  // NOLINT(runtime/int)
+                     std::ostream* msgs = 0,
+                     double rel_tol = 1e-6,
+                     double abs_tol = 1e-6,
+                     long int max_num_steps = 1e6) {  // NOLINT(runtime/int)
   std::vector<std::vector<T4> > vec_pMatrix(1, pMatrix);
 
   return generalOdeModel_rk45(f, nCmt,
@@ -156,9 +162,10 @@ generalOdeModel_rk45(const F& f,
                      const std::vector<T4>& pMatrix,
                      const std::vector<T5>& biovar,
                      const std::vector<std::vector<T6> >& tlag,
-                     double rel_tol = 1e-10,
-                     double abs_tol = 1e-10,
-                     long int max_num_steps = 1e8) {  // NOLINT(runtime/int)
+                     std::ostream* msgs = 0,
+                     double rel_tol = 1e-6,
+                     double abs_tol = 1e-6,
+                     long int max_num_steps = 1e6) {  // NOLINT(runtime/int)
   std::vector<std::vector<T4> > vec_pMatrix(1, pMatrix);
   std::vector<std::vector<T5> > vec_biovar(1, biovar);
 
@@ -189,9 +196,10 @@ generalOdeModel_rk45(const F& f,
                      const std::vector<T4>& pMatrix,
                      const std::vector<T5>& biovar,
                      const std::vector<T6>& tlag,
-                     double rel_tol = 1e-10,
-                     double abs_tol = 1e-10,
-                     long int max_num_steps = 1e8) {  // NOLINT(runtime/int)
+                     std::ostream* msgs = 0,
+                     double rel_tol = 1e-6,
+                     double abs_tol = 1e-6,
+                     long int max_num_steps = 1e6) {  // NOLINT(runtime/int)
   std::vector<std::vector<T4> > vec_pMatrix(1, pMatrix);
   std::vector<std::vector<T5> > vec_biovar(1, biovar);
   std::vector<std::vector<T6> > vec_tlag(1, tlag);
@@ -223,9 +231,10 @@ generalOdeModel_rk45(const F& f,
                      const std::vector<T4>& pMatrix,
                      const std::vector<std::vector<T5> >& biovar,
                      const std::vector<T6>& tlag,
-                     double rel_tol = 1e-10,
-                     double abs_tol = 1e-10,
-                     long int max_num_steps = 1e8) {  // NOLINT(runtime/int)
+                     std::ostream* msgs = 0,
+                     double rel_tol = 1e-6,
+                     double abs_tol = 1e-6,
+                     long int max_num_steps = 1e6) {  // NOLINT(runtime/int)
   std::vector<std::vector<T4> > vec_pMatrix(1, pMatrix);
   std::vector<std::vector<T6> > vec_tlag(1, tlag);
 
@@ -256,9 +265,10 @@ generalOdeModel_rk45(const F& f,
                      const std::vector<std::vector<T4> >& pMatrix,
                      const std::vector<T5>& biovar,
                      const std::vector<std::vector<T6> >& tlag,
-                     double rel_tol = 1e-10,
-                     double abs_tol = 1e-10,
-                     long int max_num_steps = 1e8) {  // NOLINT(runtime/int)
+                     std::ostream* msgs = 0,
+                     double rel_tol = 1e-6,
+                     double abs_tol = 1e-6,
+                     long int max_num_steps = 1e6) {  // NOLINT(runtime/int)
   std::vector<std::vector<T5> > vec_biovar(1, biovar);
 
   return generalOdeModel_rk45(f, nCmt,
@@ -288,9 +298,10 @@ generalOdeModel_rk45(const F& f,
                      const std::vector<std::vector<T4> >& pMatrix,
                      const std::vector<T5>& biovar,
                      const std::vector<T6>& tlag,
-                     double rel_tol = 1e-10,
-                     double abs_tol = 1e-10,
-                     long int max_num_steps = 1e8) {  // NOLINT(runtime/int)
+                     std::ostream* msgs = 0,
+                     double rel_tol = 1e-6,
+                     double abs_tol = 1e-6,
+                     long int max_num_steps = 1e6) {  // NOLINT(runtime/int)
   std::vector<std::vector<T5> > vec_biovar(1, biovar);
   std::vector<std::vector<T6> > vec_tlag(1, tlag);
 
@@ -321,9 +332,10 @@ generalOdeModel_rk45(const F& f,
                      const std::vector<std::vector<T4> >& pMatrix,
                      const std::vector<std::vector<T5> >& biovar,
                      const std::vector<T6>& tlag,
-                     double rel_tol = 1e-10,
-                     double abs_tol = 1e-10,
-                     long int max_num_steps = 1e8) {  // NOLINT(runtime/int)
+                     std::ostream* msgs = 0,
+                     double rel_tol = 1e-6,
+                     double abs_tol = 1e-6,
+                     long int max_num_steps = 1e6) {  // NOLINT(runtime/int)
   std::vector<std::vector<T6> > vec_tlag(1, tlag);
 
   return generalOdeModel_rk45(f, nCmt,

--- a/stan/math/torsten/generalOdeModel_rk45.hpp
+++ b/stan/math/torsten/generalOdeModel_rk45.hpp
@@ -137,7 +137,8 @@ generalOdeModel_rk45(const F& f,
 
   return generalOdeModel_rk45(f, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss,
-                              vec_pMatrix, biovar, tlag);
+                              vec_pMatrix, biovar, tlag,
+                              msgs, rel_tol, abs_tol, max_num_steps);
 }
 
 /**
@@ -171,7 +172,8 @@ generalOdeModel_rk45(const F& f,
 
   return generalOdeModel_rk45(f, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss,
-                              vec_pMatrix, vec_biovar, tlag);
+                              vec_pMatrix, vec_biovar, tlag,
+                              msgs, rel_tol, abs_tol, max_num_steps);
 }
 
 /**
@@ -206,7 +208,8 @@ generalOdeModel_rk45(const F& f,
 
   return generalOdeModel_rk45(f, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss,
-                              vec_pMatrix, vec_biovar, vec_tlag);
+                              vec_pMatrix, vec_biovar, vec_tlag,
+                              msgs, rel_tol, abs_tol, max_num_steps);
 }
 
 /**
@@ -240,7 +243,8 @@ generalOdeModel_rk45(const F& f,
 
   return generalOdeModel_rk45(f, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss,
-                              vec_pMatrix, biovar, vec_tlag);
+                              vec_pMatrix, biovar, vec_tlag,
+                              msgs, rel_tol, abs_tol, max_num_steps);
 }
 
 /**
@@ -273,7 +277,8 @@ generalOdeModel_rk45(const F& f,
 
   return generalOdeModel_rk45(f, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss,
-                              pMatrix, vec_biovar, tlag);
+                              pMatrix, vec_biovar, tlag,
+                              msgs, rel_tol, abs_tol, max_num_steps);
 }
 
 /**
@@ -307,7 +312,8 @@ generalOdeModel_rk45(const F& f,
 
   return generalOdeModel_rk45(f, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss,
-                              pMatrix, vec_biovar, vec_tlag);
+                              pMatrix, vec_biovar, vec_tlag,
+                              msgs, rel_tol, abs_tol, max_num_steps);
 }
 
 /**
@@ -340,7 +346,8 @@ generalOdeModel_rk45(const F& f,
 
   return generalOdeModel_rk45(f, nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss,
-                              pMatrix, biovar, vec_tlag);
+                              pMatrix, biovar, vec_tlag,
+                              msgs, rel_tol, abs_tol, max_num_steps);
 }
 
 #endif

--- a/test/unit/math/torsten/generalOdeModel_test.cpp
+++ b/test/unit/math/torsten/generalOdeModel_test.cpp
@@ -45,7 +45,7 @@ TEST(Torsten, genCpt_One_SingleDose) {
   using Eigen::Matrix;
   using Eigen::Dynamic;
 
-  double rel_err = 1e-6;
+  // double rel_err = 1e-6;
 
   vector<vector<double> > pMatrix(1);
   pMatrix[0].resize(3);
@@ -88,14 +88,15 @@ TEST(Torsten, genCpt_One_SingleDose) {
 	
   vector<int> ss(10, 0);
 
-  double rel_tol = 1e-8, abs_tol = 1e-8;
-  long int max_num_steps = 1e8;
+  // double rel_tol = 1e-8, abs_tol = 1e-8;
+  double rel_tol = 1e-4, abs_tol = 1e-4;
+  long int max_num_steps = 1e4;
   Matrix<double, Eigen::Dynamic, Eigen::Dynamic> x_rk45;
   x_rk45 = generalOdeModel_rk45(oneCptModelODE_functor(), nCmt,
                                 time, amt, rate, ii, evid, cmt, addl, ss,
                                 pMatrix, biovar, tlag,
                                 rel_tol, abs_tol, max_num_steps);
-
+/*
   Matrix<double, Eigen::Dynamic, Eigen::Dynamic> x_bdf;
   x_bdf = generalOdeModel_bdf(oneCptModelODE_functor(), nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss,
@@ -126,10 +127,10 @@ TEST(Torsten, genCpt_One_SingleDose) {
   test_generalOdeModel(oneCptModelODE_functor(), nCmt,
                        time, amt, rate, ii, evid, cmt, addl, ss,
                        pMatrix, biovar, tlag,
-                       rel_tol, abs_tol, max_num_steps, diff, diff2, "bdf");
+                       rel_tol, abs_tol, max_num_steps, diff, diff2, "bdf"); */
   
 }
-
+/*
 TEST(Torsten, genCpt_One_SingleDose_overload) {
   using std::vector;
   using Eigen::Matrix;
@@ -1035,4 +1036,4 @@ TEST(Torsten, genCptOne_MultipleDoses_timePara) {
                        time, amt, rate, ii, evid, cmt, addl, ss,
                        pMatrix, biovar, tlag,
                        rel_tol, abs_tol, max_num_steps, diff, diff2, "bdf");
-}
+} */

--- a/test/unit/math/torsten/generalOdeModel_test.cpp
+++ b/test/unit/math/torsten/generalOdeModel_test.cpp
@@ -45,7 +45,7 @@ TEST(Torsten, genCpt_One_SingleDose) {
   using Eigen::Matrix;
   using Eigen::Dynamic;
 
-  // double rel_err = 1e-6;
+  double rel_err = 1e-6;
 
   vector<vector<double> > pMatrix(1);
   pMatrix[0].resize(3);
@@ -94,12 +94,14 @@ TEST(Torsten, genCpt_One_SingleDose) {
   x_rk45 = generalOdeModel_rk45(oneCptModelODE_functor(), nCmt,
                                 time, amt, rate, ii, evid, cmt, addl, ss,
                                 pMatrix, biovar, tlag,
+                                0,
                                 rel_tol, abs_tol, max_num_steps);
-/*
+
   Matrix<double, Eigen::Dynamic, Eigen::Dynamic> x_bdf;
   x_bdf = generalOdeModel_bdf(oneCptModelODE_functor(), nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss,
                               pMatrix, biovar, tlag,
+                              0,
                               rel_tol, abs_tol, max_num_steps);
 
   Matrix<double, Dynamic, Dynamic> amounts(10, nCmt);
@@ -118,7 +120,7 @@ TEST(Torsten, genCpt_One_SingleDose) {
   expect_near_matrix_eq(amounts, x_bdf, rel_err);
 
   // Test AutoDiff against FiniteDiff
-  double diff = 1e-8, diff2 = 3e-3;
+  double diff = 1e-8, diff2 = 5e-3;
   test_generalOdeModel(oneCptModelODE_functor(), nCmt,
                        time, amt, rate, ii, evid, cmt, addl, ss,
                        pMatrix, biovar, tlag,
@@ -126,17 +128,17 @@ TEST(Torsten, genCpt_One_SingleDose) {
   test_generalOdeModel(oneCptModelODE_functor(), nCmt,
                        time, amt, rate, ii, evid, cmt, addl, ss,
                        pMatrix, biovar, tlag,
-                       rel_tol, abs_tol, max_num_steps, diff, diff2, "bdf"); */
+                       rel_tol, abs_tol, max_num_steps, diff, diff2, "bdf");
   
 }
-/*
+
 TEST(Torsten, genCpt_One_SingleDose_overload) {
   using std::vector;
   using Eigen::Matrix;
   using Eigen::Dynamic;
 
-  double rel_err = 1e-6;
-  
+  double rel_err = 1e-4;
+
   vector<vector<double> > pMatrix(1);
   pMatrix[0].resize(3);
   pMatrix[0][0] = 10;  // CL
@@ -163,59 +165,66 @@ TEST(Torsten, genCpt_One_SingleDose_overload) {
   amt[0] = 1000;
 
   vector<double> rate(10, 0);
-	
+
   vector<int> cmt(10, 2);
   cmt[0] = 1;
-	
+
   vector<int> evid(10, 0);
   evid[0] = 1;
 
   vector<double> ii(10, 0);
   ii[0] = 12;
-	
+
   vector<int> addl(10, 0);
   addl[0] = 14;
-	
+
   vector<int> ss(10, 0);
 
   double rel_tol = 1e-8, abs_tol = 1e-8;
   long int max_num_steps = 1e8;
-  
+
   Matrix<double, Eigen::Dynamic, Eigen::Dynamic> x_rk45_122, x_rk45_112, 
     x_rk45_111, x_rk45_121, x_rk45_212, x_rk45_211, x_rk45_221;
   x_rk45_122 = generalOdeModel_rk45(oneCptModelODE_functor(), nCmt,
                                 time, amt, rate, ii, evid, cmt, addl, ss,
                                 pMatrix[0], biovar, tlag,
+                                0,
                                 rel_tol, abs_tol, max_num_steps);
 
   x_rk45_112 = generalOdeModel_rk45(oneCptModelODE_functor(), nCmt,
                                     time, amt, rate, ii, evid, cmt, addl, ss,
                                     pMatrix[0], biovar[0], tlag,
+                                    0,
                                     rel_tol, abs_tol, max_num_steps);
   
   x_rk45_111 = generalOdeModel_rk45(oneCptModelODE_functor(), nCmt,
                                     time, amt, rate, ii, evid, cmt, addl, ss,
                                     pMatrix[0], biovar[0], tlag[0],
+                                    0,
                                     rel_tol, abs_tol, max_num_steps);
   
   x_rk45_121 = generalOdeModel_rk45(oneCptModelODE_functor(), nCmt,
                                     time, amt, rate, ii, evid, cmt, addl, ss,
                                     pMatrix[0], biovar, tlag[0],
+                                    0,
                                     rel_tol, abs_tol, max_num_steps);
   
   x_rk45_212 = generalOdeModel_rk45(oneCptModelODE_functor(), nCmt,
                                     time, amt, rate, ii, evid, cmt, addl, ss,
                                     pMatrix, biovar[0], tlag,
+                                    0,
                                     rel_tol, abs_tol, max_num_steps);
   
   x_rk45_211 = generalOdeModel_rk45(oneCptModelODE_functor(), nCmt,
                                     time, amt, rate, ii, evid, cmt, addl, ss,
                                     pMatrix, biovar[0], tlag[0],
+                                    0,
                                     rel_tol, abs_tol, max_num_steps);
   
   x_rk45_221 = generalOdeModel_rk45(oneCptModelODE_functor(), nCmt,
                                     time, amt, rate, ii, evid, cmt, addl, ss,
                                     pMatrix, biovar, tlag[0],
+                                    0,
                                     rel_tol, abs_tol, max_num_steps);
 
 
@@ -224,36 +233,43 @@ TEST(Torsten, genCpt_One_SingleDose_overload) {
   x_bdf_122 = generalOdeModel_bdf(oneCptModelODE_functor(), nCmt,
                                     time, amt, rate, ii, evid, cmt, addl, ss,
                                     pMatrix[0], biovar, tlag,
+                                    0,
                                     rel_tol, abs_tol, max_num_steps);
   
   x_bdf_112 = generalOdeModel_bdf(oneCptModelODE_functor(), nCmt,
                                     time, amt, rate, ii, evid, cmt, addl, ss,
                                     pMatrix[0], biovar[0], tlag,
+                                    0,
                                     rel_tol, abs_tol, max_num_steps);
   
   x_bdf_111 = generalOdeModel_bdf(oneCptModelODE_functor(), nCmt,
                                     time, amt, rate, ii, evid, cmt, addl, ss,
                                     pMatrix[0], biovar[0], tlag[0],
+                                    0,
                                     rel_tol, abs_tol, max_num_steps);
   
   x_bdf_121 = generalOdeModel_bdf(oneCptModelODE_functor(), nCmt,
                                     time, amt, rate, ii, evid, cmt, addl, ss,
                                     pMatrix[0], biovar, tlag[0],
+                                    0,
                                     rel_tol, abs_tol, max_num_steps);
   
   x_bdf_212 = generalOdeModel_bdf(oneCptModelODE_functor(), nCmt,
                                     time, amt, rate, ii, evid, cmt, addl, ss,
                                     pMatrix, biovar[0], tlag,
+                                    0,
                                     rel_tol, abs_tol, max_num_steps);
   
   x_bdf_211 = generalOdeModel_bdf(oneCptModelODE_functor(), nCmt,
                                     time, amt, rate, ii, evid, cmt, addl, ss,
                                     pMatrix, biovar[0], tlag[0],
+                                    0,
                                     rel_tol, abs_tol, max_num_steps);
   
   x_bdf_221 = generalOdeModel_bdf(oneCptModelODE_functor(), nCmt,
                                     time, amt, rate, ii, evid, cmt, addl, ss,
                                     pMatrix, biovar, tlag[0],
+                                    0,
                                     rel_tol, abs_tol, max_num_steps);  
 	
   Matrix<double, Dynamic, Dynamic> amounts(10, 2);
@@ -291,7 +307,7 @@ TEST(Torsten, linOdeModel_signature_test) {
   using Eigen::Matrix;
   using Eigen::Dynamic;
   
-  double rel_err = 1e-6;
+  double rel_err = 1e-4;
   
   vector<vector<double> > pMatrix(1);
   pMatrix[0].resize(3);
@@ -370,30 +386,37 @@ TEST(Torsten, linOdeModel_signature_test) {
   x_rk45_122[0] = generalOdeModel_rk45(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix_v[0], biovar, tlag,
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_rk45_122[1] = generalOdeModel_rk45(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix_v[0], biovar_v, tlag,
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_rk45_122[2] = generalOdeModel_rk45(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix_v[0], biovar, tlag_v,
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_rk45_122[3] = generalOdeModel_rk45(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix_v[0], biovar_v, tlag_v,
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_rk45_122[4] = generalOdeModel_rk45(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix[0], biovar_v, tlag,
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_rk45_122[5] = generalOdeModel_rk45(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix[0], biovar_v, tlag_v,
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_rk45_122[5] = generalOdeModel_rk45(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix[0], biovar, tlag_v,
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   
   for (size_t i = 0; i < x_rk45_122.size(); i++)
@@ -407,30 +430,37 @@ TEST(Torsten, linOdeModel_signature_test) {
   x_rk45_112[0] = generalOdeModel_rk45(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix_v[0], biovar[0], tlag,
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_rk45_112[1] = generalOdeModel_rk45(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix_v[0], biovar_v[0], tlag,
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_rk45_112[2] = generalOdeModel_rk45(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix_v[0], biovar[0], tlag_v,
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_rk45_112[3] = generalOdeModel_rk45(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix_v[0], biovar_v[0], tlag_v,
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_rk45_112[4] = generalOdeModel_rk45(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix[0], biovar_v[0], tlag,
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_rk45_112[5] = generalOdeModel_rk45(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix[0], biovar_v[0], tlag_v,
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_rk45_112[5] = generalOdeModel_rk45(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix[0], biovar[0], tlag_v,
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   
   for (size_t i = 0; i < x_rk45_112.size(); i++)
@@ -444,30 +474,37 @@ TEST(Torsten, linOdeModel_signature_test) {
   x_rk45_121[0] = generalOdeModel_rk45(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix_v[0], biovar, tlag[0],
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_rk45_121[1] = generalOdeModel_rk45(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix_v[0], biovar_v, tlag[0],
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_rk45_121[2] = generalOdeModel_rk45(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix_v[0], biovar, tlag_v[0],
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_rk45_121[3] = generalOdeModel_rk45(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix_v[0], biovar_v, tlag_v[0],
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_rk45_121[4] = generalOdeModel_rk45(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix[0], biovar_v, tlag[0],
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_rk45_121[5] = generalOdeModel_rk45(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix[0], biovar_v, tlag_v[0],
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_rk45_121[5] = generalOdeModel_rk45(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix[0], biovar, tlag_v[0],
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   
   for (size_t i = 0; i < x_rk45_121.size(); i++)
@@ -481,30 +518,37 @@ TEST(Torsten, linOdeModel_signature_test) {
   x_rk45_111[0] = generalOdeModel_rk45(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix_v[0], biovar[0], tlag[0],
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_rk45_111[1] = generalOdeModel_rk45(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix_v[0], biovar_v[0], tlag[0],
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_rk45_111[2] = generalOdeModel_rk45(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix_v[0], biovar[0], tlag_v[0],
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_rk45_111[3] = generalOdeModel_rk45(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix_v[0], biovar_v[0], tlag_v[0],
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_rk45_111[4] = generalOdeModel_rk45(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix[0], biovar_v[0], tlag[0],
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_rk45_111[5] = generalOdeModel_rk45(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix[0], biovar_v[0], tlag_v[0],
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_rk45_111[5] = generalOdeModel_rk45(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix[0], biovar[0], tlag_v[0],
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   
   for (size_t i = 0; i < x_rk45_111.size(); i++)
@@ -518,30 +562,37 @@ TEST(Torsten, linOdeModel_signature_test) {
   x_rk45_211[0] = generalOdeModel_rk45(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix_v, biovar[0], tlag[0],
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_rk45_211[1] = generalOdeModel_rk45(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix_v, biovar_v[0], tlag[0],
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_rk45_211[2] = generalOdeModel_rk45(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix_v, biovar[0], tlag_v[0],
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_rk45_211[3] = generalOdeModel_rk45(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix_v, biovar_v[0], tlag_v[0],
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_rk45_211[4] = generalOdeModel_rk45(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix, biovar_v[0], tlag[0],
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_rk45_211[5] = generalOdeModel_rk45(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix, biovar_v[0], tlag_v[0],
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_rk45_211[5] = generalOdeModel_rk45(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix, biovar[0], tlag_v[0],
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   
   for (size_t i = 0; i < x_rk45_211.size(); i++)
@@ -555,30 +606,37 @@ TEST(Torsten, linOdeModel_signature_test) {
   x_rk45_221[0] = generalOdeModel_rk45(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix_v, biovar, tlag[0],
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_rk45_221[1] = generalOdeModel_rk45(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix_v, biovar_v, tlag[0],
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_rk45_221[2] = generalOdeModel_rk45(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix_v, biovar, tlag_v[0],
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_rk45_221[3] = generalOdeModel_rk45(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix_v, biovar_v, tlag_v[0],
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_rk45_221[4] = generalOdeModel_rk45(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix, biovar_v, tlag[0],
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_rk45_221[5] = generalOdeModel_rk45(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix, biovar_v, tlag_v[0],
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_rk45_221[5] = generalOdeModel_rk45(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix, biovar, tlag_v[0],
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   
   for (size_t i = 0; i < x_rk45_221.size(); i++)
@@ -593,30 +651,37 @@ TEST(Torsten, linOdeModel_signature_test) {
   x_bdf_122[0] = generalOdeModel_bdf(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix_v[0], biovar, tlag,
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_bdf_122[1] = generalOdeModel_bdf(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix_v[0], biovar_v, tlag,
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_bdf_122[2] = generalOdeModel_bdf(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix_v[0], biovar, tlag_v,
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_bdf_122[3] = generalOdeModel_bdf(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix_v[0], biovar_v, tlag_v,
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_bdf_122[4] = generalOdeModel_bdf(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix[0], biovar_v, tlag,
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_bdf_122[5] = generalOdeModel_bdf(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix[0], biovar_v, tlag_v,
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_bdf_122[5] = generalOdeModel_bdf(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix[0], biovar, tlag_v,
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   
   for (size_t i = 0; i < x_bdf_122.size(); i++)
@@ -630,30 +695,37 @@ TEST(Torsten, linOdeModel_signature_test) {
   x_bdf_112[0] = generalOdeModel_bdf(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix_v[0], biovar[0], tlag,
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_bdf_112[1] = generalOdeModel_bdf(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix_v[0], biovar_v[0], tlag,
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_bdf_112[2] = generalOdeModel_bdf(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix_v[0], biovar[0], tlag_v,
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_bdf_112[3] = generalOdeModel_bdf(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix_v[0], biovar_v[0], tlag_v,
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_bdf_112[4] = generalOdeModel_bdf(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix[0], biovar_v[0], tlag,
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_bdf_112[5] = generalOdeModel_bdf(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix[0], biovar_v[0], tlag_v,
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_bdf_112[5] = generalOdeModel_bdf(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix[0], biovar[0], tlag_v,
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   
   for (size_t i = 0; i < x_bdf_112.size(); i++)
@@ -667,30 +739,37 @@ TEST(Torsten, linOdeModel_signature_test) {
   x_bdf_121[0] = generalOdeModel_bdf(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix_v[0], biovar, tlag[0],
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_bdf_121[1] = generalOdeModel_bdf(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix_v[0], biovar_v, tlag[0],
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_bdf_121[2] = generalOdeModel_bdf(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix_v[0], biovar, tlag_v[0],
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_bdf_121[3] = generalOdeModel_bdf(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix_v[0], biovar_v, tlag_v[0],
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_bdf_121[4] = generalOdeModel_bdf(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix[0], biovar_v, tlag[0],
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_bdf_121[5] = generalOdeModel_bdf(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix[0], biovar_v, tlag_v[0],
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_bdf_121[5] = generalOdeModel_bdf(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix[0], biovar, tlag_v[0],
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   
   for (size_t i = 0; i < x_bdf_121.size(); i++)
@@ -704,30 +783,37 @@ TEST(Torsten, linOdeModel_signature_test) {
   x_bdf_111[0] = generalOdeModel_bdf(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix_v[0], biovar[0], tlag[0],
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_bdf_111[1] = generalOdeModel_bdf(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix_v[0], biovar_v[0], tlag[0],
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_bdf_111[2] = generalOdeModel_bdf(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix_v[0], biovar[0], tlag_v[0],
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_bdf_111[3] = generalOdeModel_bdf(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix_v[0], biovar_v[0], tlag_v[0],
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_bdf_111[4] = generalOdeModel_bdf(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix[0], biovar_v[0], tlag[0],
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_bdf_111[5] = generalOdeModel_bdf(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix[0], biovar_v[0], tlag_v[0],
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_bdf_111[5] = generalOdeModel_bdf(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix[0], biovar[0], tlag_v[0],
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   
   for (size_t i = 0; i < x_bdf_111.size(); i++)
@@ -741,30 +827,37 @@ TEST(Torsten, linOdeModel_signature_test) {
   x_bdf_211[0] = generalOdeModel_bdf(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix_v, biovar[0], tlag[0],
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_bdf_211[1] = generalOdeModel_bdf(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix_v, biovar_v[0], tlag[0],
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_bdf_211[2] = generalOdeModel_bdf(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix_v, biovar[0], tlag_v[0],
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_bdf_211[3] = generalOdeModel_bdf(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix_v, biovar_v[0], tlag_v[0],
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_bdf_211[4] = generalOdeModel_bdf(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix, biovar_v[0], tlag[0],
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_bdf_211[5] = generalOdeModel_bdf(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix, biovar_v[0], tlag_v[0],
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_bdf_211[5] = generalOdeModel_bdf(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix, biovar[0], tlag_v[0],
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   
   for (size_t i = 0; i < x_bdf_211.size(); i++)
@@ -778,30 +871,37 @@ TEST(Torsten, linOdeModel_signature_test) {
   x_bdf_221[0] = generalOdeModel_bdf(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix_v, biovar, tlag[0],
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_bdf_221[1] = generalOdeModel_bdf(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix_v, biovar_v, tlag[0],
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_bdf_221[2] = generalOdeModel_bdf(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix_v, biovar, tlag_v[0],
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_bdf_221[3] = generalOdeModel_bdf(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix_v, biovar_v, tlag_v[0],
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_bdf_221[4] = generalOdeModel_bdf(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix, biovar_v, tlag[0],
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_bdf_221[5] = generalOdeModel_bdf(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix, biovar_v, tlag_v[0],
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   x_bdf_221[5] = generalOdeModel_bdf(oneCptModelODE_functor(), nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix, biovar, tlag_v[0],
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   
   for (size_t i = 0; i < x_bdf_221.size(); i++)
@@ -908,12 +1008,14 @@ TEST(Torsten, genCpt_One_abstime_SingleDose) {
   x_rk45 = generalOdeModel_rk45(oneCptModelODE_abstime_functor(), 2,
                                 time, amt, rate, ii, evid, cmt, addl, ss,
                                 pMatrix, biovar, tlag,
+                                0,
                                 rel_tol, abs_tol, max_num_steps);
   
   Matrix<double, Eigen::Dynamic, Eigen::Dynamic> x_bdf;
   x_bdf = generalOdeModel_bdf(oneCptModelODE_abstime_functor(), 2,
                               time, amt, rate, ii, evid, cmt, addl, ss,
                               pMatrix, biovar, tlag,
+                              0,
                               rel_tol, abs_tol, max_num_steps);
 	
   Matrix<double, Dynamic, Dynamic> amounts(10, 2);
@@ -1001,12 +1103,14 @@ TEST(Torsten, genCptOne_MultipleDoses_timePara) {
    x_rk45 = generalOdeModel_rk45(oneCptModelODE_functor(), nCmt,
                                  time, amt, rate, ii, evid, cmt, addl, ss,
                                  pMatrix, biovar, tlag,
+                                 0,
                                  rel_tol, abs_tol, max_num_steps);
   
   Matrix<double, Eigen::Dynamic, Eigen::Dynamic> x_bdf;
   x_bdf = generalOdeModel_bdf(oneCptModelODE_functor(), nCmt,
                               time, amt, rate, ii, evid, cmt, addl, ss,
                               pMatrix, biovar, tlag,
+                              0,
                               rel_tol, abs_tol, max_num_steps);
 
 	Matrix<double, Dynamic, Dynamic> amounts(nEvent, 2);
@@ -1026,7 +1130,7 @@ TEST(Torsten, genCptOne_MultipleDoses_timePara) {
     expect_near_matrix_eq(amounts, x_bdf, rel_err_bdf);
 
   // Test AutoDiff against FiniteDiff
-  double diff = 1e-8, diff2 = 1e-2;
+  double diff = 1e-8, diff2 = 2e-2;
   test_generalOdeModel(oneCptModelODE_functor(), nCmt,
                        time, amt, rate, ii, evid, cmt, addl, ss,
                        pMatrix, biovar, tlag,
@@ -1035,4 +1139,4 @@ TEST(Torsten, genCptOne_MultipleDoses_timePara) {
                        time, amt, rate, ii, evid, cmt, addl, ss,
                        pMatrix, biovar, tlag,
                        rel_tol, abs_tol, max_num_steps, diff, diff2, "bdf");
-} */
+}

--- a/test/unit/math/torsten/generalOdeModel_test.cpp
+++ b/test/unit/math/torsten/generalOdeModel_test.cpp
@@ -88,9 +88,8 @@ TEST(Torsten, genCpt_One_SingleDose) {
 	
   vector<int> ss(10, 0);
 
-  // double rel_tol = 1e-8, abs_tol = 1e-8;
-  double rel_tol = 1e-4, abs_tol = 1e-4;
-  long int max_num_steps = 1e4;
+  double rel_tol = 1e-8, abs_tol = 1e-8;
+  long int max_num_steps = 1e8;
   Matrix<double, Eigen::Dynamic, Eigen::Dynamic> x_rk45;
   x_rk45 = generalOdeModel_rk45(oneCptModelODE_functor(), nCmt,
                                 time, amt, rate, ii, evid, cmt, addl, ss,

--- a/test/unit/math/torsten/util_generalOdeModel.hpp
+++ b/test/unit/math/torsten/util_generalOdeModel.hpp
@@ -84,18 +84,26 @@ finite_diff_params(const F& f,
   if (odeInt == "rk45") {
     pk_res_ub = generalOdeModel_rk45(f, nCmt, time, amt, rate, ii,
                                      evid, cmt, addl, ss,
-                                     pMatrix_ub, biovar_ub, tlag_ub);
+                                     pMatrix_ub, biovar_ub, tlag_ub,
+                                     0,
+                                     rel_tol, abs_tol, max_num_steps);
     pk_res_lb = generalOdeModel_rk45(f, nCmt, time, amt, rate, ii,
                                      evid, cmt, addl, ss,
-                                     pMatrix_lb, biovar_lb, tlag_lb);
+                                     pMatrix_lb, biovar_lb, tlag_lb,
+                                     0,
+                                     rel_tol, abs_tol, max_num_steps);
   }
   if (odeInt == "bdf") {
     pk_res_ub = generalOdeModel_bdf(f, nCmt, time, amt, rate, ii,
                                     evid, cmt, addl, ss,
-                                    pMatrix_ub, biovar_ub, tlag_ub);
+                                    pMatrix_ub, biovar_ub, tlag_ub,
+                                    0,
+                                    rel_tol, abs_tol, max_num_steps);
     pk_res_lb = generalOdeModel_bdf(f, nCmt, time, amt, rate, ii,
                                     evid, cmt, addl, ss,
-                                    pMatrix_lb, biovar_lb, tlag_lb); 
+                                    pMatrix_lb, biovar_lb, tlag_lb,
+                                    0,
+                                    rel_tol, abs_tol, max_num_steps); 
   }
   return (pk_res_ub - pk_res_lb) / (2 * diff);
 }
@@ -164,12 +172,14 @@ void test_generalOdeModel_finite_diff_vdd(
     ode_res = generalOdeModel_rk45(f, nCmt,
                                    time, amt, rate, ii, evid, cmt, addl, ss,
                                    pMatrix_v, biovar, tlag,
+                                   0,
                                    rel_tol, abs_tol, max_num_steps);
 
   if (odeInt == "bdf")
     ode_res = generalOdeModel_bdf(f, nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix_v, biovar, tlag,
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
 
   size_t nEvent = time.size();
@@ -260,12 +270,14 @@ void test_generalOdeModel_finite_diff_dvd(
     ode_res = generalOdeModel_rk45(f, nCmt,
                                    time, amt, rate, ii, evid, cmt, addl, ss,
                                    pMatrix, biovar_v, tlag,
+                                   0,
                                    rel_tol, abs_tol, max_num_steps);
   
   if (odeInt == "bdf")
     ode_res = generalOdeModel_bdf(f, nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix, biovar_v, tlag,
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
   
   size_t nEvent = time.size();
@@ -359,12 +371,14 @@ void test_generalOdeModel_finite_diff_ddv(
     ode_res = generalOdeModel_rk45(f, nCmt,
                                    time, amt, rate, ii, evid, cmt, addl, ss,
                                    pMatrix, biovar, tlag_v,
+                                   0,
                                    rel_tol, abs_tol, max_num_steps);
 
   if (odeInt == "bdf")
     ode_res = generalOdeModel_bdf(f, nCmt,
                                   time, amt, rate, ii, evid, cmt, addl, ss,
                                   pMatrix, biovar, tlag_v,
+                                  0,
                                   rel_tol, abs_tol, max_num_steps);
 
   size_t nEvent = time.size();


### PR DESCRIPTION
#### Submisison Checklist

- [X] Run unit tests: `./runTests.py test/unit/torsten`
- [X] Run cpplint: `make cpplint`
- [X] Declare copyright holder and open-source license: see below

#### Summary:
Solves https://github.com/charlesm93/stan/issues/6. Allows users to adjust the tuning parameters of the ODE integrators for generalOdeModel_*. There was technically nothing wrong with the functions in the math repo, but there was a disagreement between the math and the stan repos.

This pull request, combined with one I'm about to make on the Stan repo, fixes this issue by adding the `msgs` argument. I will eventually remove it because it doesn't get used. That said, it's harmless and it's a straightforward fix. The grammar files for generalOdeModel_* follow closely the architecture used for the integrate_ode_* functions, which have a msgs argument. This argument is treated differently than the other arguments, which is why I missed (removing) it when constructing the new grammar files; loosely speaking, it became part of the grammar for generalOdeModel_*. Changing that grammar requires a bit of refactoring and is not my immediate priority.

This fix is not ideal; we could attempt a better one, but the only effect would be a marginal improvement in code readability.

#### How to Verify:
This is tricky. In `integrate_ode_*.hpp` add a print statement (or an EXPECT_EQ statement) to see the value of the tuning parameters (rel_tol, abs_tol, and max_num_steps). 

I'm not sure how to design a unit test for this, because the error only comes up when I run a Stan model. I do not want to add an EXPECT_EQ statement inside a stan function (integrate_ode_* in this case). Doing so requires changing the Stan makefile to include the gtest library and means we'll have printing statements from the unit test while running Stan! Highly undesirable. 

Suggestions welcomed!

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Metrum Research Group, LLC

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
